### PR TITLE
feat(diag): admin-only rate-limit runtime diagnostic endpoint

### DIFF
--- a/src/app/api/_diagnostics/rate-limit/route.ts
+++ b/src/app/api/_diagnostics/rate-limit/route.ts
@@ -1,0 +1,102 @@
+/**
+ * GET /api/_diagnostics/rate-limit
+ *
+ * Admin-only runtime diagnostic for Finding #54. Returns the actual state
+ * of the rate-limit pipeline in production — which backend is active, whether
+ * the Upstash env vars are seen by the runtime, and a live ping result.
+ *
+ * The smoke test scripts/ai-gating-smoke.test.ts sees 60/60 = 400 and zero
+ * 429 in burst against /api/ai/exercise-chat even though:
+ *   - UPSTASH_REDIS_REST_URL + _TOKEN are configured in Vercel (scope: All)
+ *   - The Upstash instance is active (literate-corgi, ~5.7K/10K commands today)
+ *
+ * So the rate-limit is falling back to memory-per-instance silently. This
+ * endpoint pinpoints exactly where.
+ *
+ * Response shape:
+ *   {
+ *     backend: 'memory' | 'redis',
+ *     upstashEnvSeenByRuntime: { url: boolean, token: boolean },
+ *     livePingMs: number | null,
+ *     livePingResult: { allowed, remaining, resetAt } | null,
+ *     livePingError: string | null,
+ *     directFetchStatus: number | null,
+ *     directFetchError: string | null,
+ *   }
+ *
+ * After the Finding #54 root cause is understood and fixed, this endpoint
+ * can be removed (or gated behind a feature flag).
+ */
+import { NextResponse } from 'next/server'
+import { requireRole } from '@/utils/auth/route'
+import { checkRateLimitAsync, RATE_LIMIT_BACKEND } from '@/utils/rateLimit'
+import { env } from '@/utils/env'
+import { randomBytes } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request) {
+  const auth = await requireRole(['admin'])
+  if (!auth.ok) return auth.response
+
+  const urlEnv = env.upstash.restUrl.trim()
+  const tokenEnv = env.upstash.restToken.trim()
+
+  const nonceKey = `_diag:${randomBytes(4).toString('hex')}`
+
+  // Trigger the same code path as the rate-limit in production. First call
+  // forces the redis branch when envs are set; fallback to memory on fetch
+  // failure. After this call, RATE_LIMIT_BACKEND should have flipped to
+  // 'redis' if Upstash is reachable.
+  let livePingResult = null
+  let livePingError: string | null = null
+  const t0 = Date.now()
+  try {
+    livePingResult = await checkRateLimitAsync(nonceKey, 1000, 60_000)
+  } catch (e) {
+    livePingError = e instanceof Error ? e.message : String(e)
+  }
+  const livePingMs = Date.now() - t0
+
+  // Second diagnostic: direct fetch against Upstash REST without going through
+  // the helper. Isolates whether the issue is fetch-level (DNS, TLS, routing).
+  let directFetchStatus: number | null = null
+  let directFetchError: string | null = null
+  if (urlEnv && tokenEnv) {
+    try {
+      const r = await fetch(`${urlEnv}/ping`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${tokenEnv}` },
+      })
+      directFetchStatus = r.status
+      // Don't include the body — may leak server identifier. We only want the
+      // status code to know if TLS/auth reached Upstash.
+    } catch (e) {
+      directFetchError = e instanceof Error ? e.message : String(e)
+    }
+  }
+
+  return NextResponse.json(
+    {
+      backend: RATE_LIMIT_BACKEND,
+      upstashEnvSeenByRuntime: {
+        url: !!urlEnv,
+        token: !!tokenEnv,
+        urlLen: urlEnv.length,
+        tokenLen: tokenEnv.length,
+      },
+      livePingMs,
+      livePingResult,
+      livePingError,
+      directFetchStatus,
+      directFetchError,
+      runtimeEnv: {
+        VERCEL: process.env.VERCEL ?? null,
+        VERCEL_ENV: process.env.VERCEL_ENV ?? null,
+        VERCEL_REGION: process.env.VERCEL_REGION ?? null,
+        NODE_ENV: process.env.NODE_ENV ?? null,
+      },
+    },
+    { headers: { 'cache-control': 'no-store, max-age=0' } }
+  )
+}


### PR DESCRIPTION
## Summary

Endpoint \`GET /api/_diagnostics/rate-limit\` (admin-only) pra identificar a **causa raiz do [#54](https://github.com/irontracks/irontracks/issues/54)**. Diagnóstico anterior confirmou:

- ✅ Envs \`UPSTASH_REDIS_REST_URL\` + \`_TOKEN\` configuradas no Vercel (escopo All, Feb 23)
- ✅ Instância Upstash \`literate-corgi\` ativa (~5.7K/10K commands hoje, TLS OK)
- ❌ Rate-limit ainda cai pra memory-per-instance (60/60 requests = 400 no smoke)

## O que o endpoint retorna

\`\`\`ts
{
  backend: 'memory' | 'redis',      // estado real após uma chamada real
  upstashEnvSeenByRuntime: {         // as envs resolvem no runtime?
    url: boolean,
    token: boolean,
    urlLen: number,
    tokenLen: number,
  },
  livePingMs: number,                // tempo de checkRateLimitAsync()
  livePingResult: { allowed, ... }, // resultado da rate-limit
  livePingError: string | null,      // erro capturado (se houve fallback)
  directFetchStatus: number | null,  // bypassa helper: fetch direto em
  directFetchError: string | null,   // /ping do Upstash REST
  runtimeEnv: {                      // self-identify onde rodou
    VERCEL, VERCEL_ENV, VERCEL_REGION, NODE_ENV
  }
}
\`\`\`

## Segurança

- Gated por \`requireRole(['admin'])\` — não-admin retorna 401/403
- **Zero valor de URL/token vazado** (só length como prova que resolveu no env)
- Cache-control: \`no-store\`

## Plano de uso

1. Merge + deploy automático via Vercel
2. Chamar \`GET /api/_diagnostics/rate-limit\` como admin
3. Interpretar:
   - \`backend=memory\` + \`livePingError=...\` → fetch Upstash falhando (causa raiz + mensagem do erro)
   - \`backend=redis\` + \`livePingResult.allowed=true\` → helper funcionando; problema é em \`/api/ai/exercise-chat\` especificamente
   - \`directFetchStatus=null\` + \`directFetchError=...\` → fetch-level (DNS/TLS/routing) com erro específico
   - \`upstashEnvSeenByRuntime.url=false\` → envs não chegaram ao runtime (config issue no Vercel)
4. Com diagnóstico, aplicar fix no PR seguinte + remover este endpoint

## Test plan

- [x] \`npx tsc --noEmit\` limpo
- [x] ESLint sem warnings
- [ ] Após deploy, autenticado como admin: \`curl https://irontracks.com.br/api/_diagnostics/rate-limit\` retorna JSON com todos os campos
- [ ] Não-admin recebe 401/403

🤖 Generated with [Claude Code](https://claude.com/claude-code)