### PR TITLE
cleanup: remove diag Sentry instrumentation

### DIFF
--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,6 +1,5 @@
 import { logError, logWarn } from '@/lib/logger'
 import { env } from '@/utils/env'
-import * as Sentry from '@sentry/nextjs'
 
 export type RateLimitResult = {
   allowed: boolean
@@ -142,25 +141,7 @@ const normalizeRateLimit = (countRaw: unknown, ttlRaw: unknown, max: number, win
 
 export const checkRateLimitAsync = async (key: string, max: number, windowMs: number): Promise<RateLimitResult> => {
   const cfg = getUpstashConfig()
-  if (!cfg) {
-    // Surface this fallback to Sentry — the memory-mode bucket is per-instance
-    // so in Vercel parallel-function runtime it silently breaks rate-limiting.
-    Sentry.captureMessage('rateLimit: fell back to memory mode — Upstash config missing', {
-      level: 'error',
-      tags: { rate_limit_fallback: 'memory_config_missing', key_prefix: key.split(':')[0] },
-    })
-    return checkRateLimit(key, max, windowMs)
-  }
-
-  // DIAG #54: breadcrumb every call with the key — Sentry will show if the
-  // key varies between concurrent requests from the same client. Remove
-  // once root cause is understood.
-  Sentry.addBreadcrumb({
-    category: 'rate-limit',
-    level: 'info',
-    message: 'checkRateLimitAsync',
-    data: { key, max, windowMs },
-  })
+  if (!cfg) return checkRateLimit(key, max, windowMs)
 
   // Upstash is available → switch backend indicator (idempotent assignment)
   RATE_LIMIT_BACKEND = 'redis'
@@ -188,33 +169,14 @@ export const checkRateLimitAsync = async (key: string, max: number, windowMs: nu
     const json = await res.json().catch((): null => null)
     const result = json && typeof json === 'object' ? (json as Record<string, unknown>).result : null
     if (Array.isArray(result) && result.length >= 2) {
-      const rl = normalizeRateLimit(result[0], result[1], max, windowMs)
-      // DIAG #54: log every rate-limit evaluation as a Sentry message so we
-      // can see exactly which key each of the 60 smoke requests is using.
-      if (key.startsWith('ai:exercise-chat:')) {
-        Sentry.captureMessage('rateLimit:probe', {
-          level: 'info',
-          tags: { probe: 'exercise-chat' },
-          extra: { key, count: result[0], remaining: rl.remaining, allowed: rl.allowed },
-        })
-      }
-      return rl
+      return normalizeRateLimit(result[0], result[1], max, windowMs)
     }
     if (Array.isArray(json) && json.length >= 2) {
       return normalizeRateLimit(json[0], json[1], max, windowMs)
     }
-    // Surface unexpected response shape to Sentry
-    Sentry.captureMessage('rateLimit: Upstash returned unexpected shape', {
-      level: 'error',
-      tags: { rate_limit_fallback: 'memory_bad_shape', key_prefix: key.split(':')[0] },
-      extra: { status: res.status, jsonShape: typeof json, hasResult: 'result' in (json || {}) },
-    })
     return checkRateLimit(key, max, windowMs)
   } catch (e) {
     logError('checkRateLimitAsync.redis', e)
-    Sentry.captureException(e, {
-      tags: { rate_limit_fallback: 'memory_fetch_error', key_prefix: key.split(':')[0] },
-    })
     return checkRateLimit(key, max, windowMs)
   }
 }


### PR DESCRIPTION
Sentry not receiving events in prod — instrumentation not useful. Keeps cache:'no-store' fix from #66.