### PR TITLE
chore(tsconfig): silence TS deprecation warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "jsx": "react-jsx",
     "incremental": true,
     "downlevelIteration": true,
+    "ignoreDeprecations": "5.0",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- Adiciona `"ignoreDeprecations": "5.0"` ao `tsconfig.json` para silenciar 3 avisos TS5107/TS5101 (`target=ES5`, `moduleResolution=node10`, `downlevelIteration`) que poluíam o output do `npx tsc --noEmit`.
- Mudança não-funcional: nenhum comportamento de compilação alterado, apenas remove warnings que de outra forma deixarão de funcionar em TS 7.0 (modernização completa do tsconfig fica para uma PR dedicada).

## Contexto
Detectado durante análise completa do projeto. Junto com este fix, também foi rodado `npm install` localmente para restaurar `vitest` (estava ausente no `node_modules`); `npm run test:unit` agora passa **75 arquivos / 1248 testes** verdes.

## Test plan
- [x] `npx tsc --noEmit` → zero saída
- [x] `npm run test:unit` → 1248/1248 passando
- [x] `npm run scan:all` → todos limpos (0 segredos, 0 botões problemáticos)
- [ ] Vercel CI passa no merge

https://claude.ai/code/session_01D47hidg9EBy5N47qg9MvdU