### PR TITLE
chore(husky): block commits that introduce hardcoded secrets

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+node scripts/scan-secrets.mjs --only-critical


### PR DESCRIPTION
## Summary
Adiciona `scan:secrets --only-critical` ao hook `pre-commit` do husky. Hoje o repo tem **0 segredos hardcoded**; este guarda fixa essa invariante e bloqueia commits que tentem introduzir JWTs, chaves Stripe, service-role keys, etc.

## Por que
- O scan já existia (`scripts/scan-secrets.mjs`) mas só rodava manualmente.
- Roda em ~600ms — sem impacto perceptível na DX.
- Falha com saída clara apontando arquivo e linha do segredo detectado.

## Test plan
- [x] `git commit` rodou o scan localmente (saída ✅)
- [x] Hook não quebra fluxo normal de commit
- [ ] Confirmar em CI que husky roda no ambiente de Vercel/CI (não roda — husky é só local; OK)

https://claude.ai/code/session_01D47hidg9EBy5N47qg9MvdU