### PR TITLE
fix(a11y): add aria-label to 46 inputs and fix scan false positives

### DIFF
--- a/scripts/scan-a11y.mjs
+++ b/scripts/scan-a11y.mjs
@@ -128,16 +128,50 @@ for (const filePath of allFiles) {
 
     // ── 3. <input> sem label associado ───────────────────────────────────────
     if (!ONLY_CRIT) {
-        const inputRe = /<input\b([^>]*?)(?:\/>|>)/gs
-        while ((m = inputRe.exec(source)) !== null) {
-            const attrs   = m[1]
-            const lineNum = source.slice(0, m.index).split('\n').length
+        // Brace-aware extractor — respeita expressões JSX {(e) => ...} dentro
+        // dos atributos, que continham `>` e quebravam o regex anterior.
+        const collectInputAttrs = () => {
+            const out = []
+            let i = 0
+            while (i < source.length) {
+                const idx = source.indexOf('<input', i)
+                if (idx === -1) break
+                const next = source[idx + 6]
+                if (next && /[A-Za-z0-9]/.test(next)) { i = idx + 6; continue }
+                let j = idx + 6
+                let depth = 0
+                let inStr = null
+                while (j < source.length) {
+                    const c = source[j]
+                    if (inStr) {
+                        if (c === '\\') { j += 2; continue }
+                        if (c === inStr) inStr = null
+                        j++; continue
+                    }
+                    if (c === '"' || c === "'" || c === '`') { inStr = c; j++; continue }
+                    if (c === '{') { depth++; j++; continue }
+                    if (c === '}') { depth--; j++; continue }
+                    if (depth === 0 && c === '>') {
+                        out.push({
+                            attrs: source.slice(idx + 6, j),
+                            lineNum: source.slice(0, idx).split('\n').length,
+                        })
+                        i = j + 1
+                        break
+                    }
+                    j++
+                }
+                if (j >= source.length) break
+            }
+            return out
+        }
 
+        for (const { attrs, lineNum } of collectInputAttrs()) {
             // Pula: hidden, checkbox/radio (geralmente embrulhados em label)
             if (/type=\{?['"`]hidden['"`]\}?/.test(attrs)) continue
             if (/type=\{?['"`](?:checkbox|radio)['"`]\}?/.test(attrs)) continue
 
-            const hasLabel = /aria-label=|aria-labelledby=|id=/.test(attrs)
+            const hasLabel = /aria-label=|aria-labelledby=|\bid=/.test(attrs)
             const hasSpread = attrs.includes('{...')
             if (!hasLabel && !hasSpread) {
                 findings.push({

--- a/src/app/(app)/dashboard/DashboardModals.tsx
+++ b/src/app/(app)/dashboard/DashboardModals.tsx
@@ -205,7 +205,7 @@ export default function DashboardModals(props: DashboardModalsProps) {
                             <button type="button" onClick={() => setShowCompleteProfile(false)} className="w-9 h-9 rounded-full bg-neutral-800 hover:bg-neutral-700 flex items-center justify-center text-neutral-400 hover:text-white transition-colors" aria-label="Fechar"><X size={18} /></button>
                         </div>
                         <label className="block text-xs font-bold uppercase tracking-widest text-neutral-500 mb-2">Nome de Exibição</label>
-                        <input value={profileDraftName} onChange={(e) => setProfileDraftName(e.target.value)} placeholder="Ex: João Silva" className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-yellow-500" />
+                        <input value={profileDraftName} onChange={(e) => setProfileDraftName(e.target.value)} placeholder="Ex: João Silva" className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-yellow-500"  aria-label="Ex: João Silva"/>
                         <div className="flex gap-2 mt-5">
                             <button type="button" onClick={() => setShowCompleteProfile(false)} disabled={savingProfile} className="flex-1 p-3 bg-neutral-800 rounded-xl font-bold text-neutral-300 disabled:opacity-50">Cancelar</button>
                             <button type="button" onClick={handleSaveProfile} disabled={savingProfile} className="flex-1 p-3 bg-yellow-500 rounded-xl font-black text-black disabled:opacity-50">{savingProfile ? 'Salvando...' : 'Salvar'}</button>
@@ -219,7 +219,7 @@ export default function DashboardModals(props: DashboardModalsProps) {
                 <div className="fixed inset-0 z-[70] bg-black/80 flex items-center justify-center p-4">
                     <div className="bg-neutral-900 p-6 rounded-2xl w-full max-w-sm border border-neutral-800">
                         <h3 className="font-bold text-white mb-4">Importar Treino (Código)</h3>
-                        <input value={importCode} onChange={e => setImportCode(e.target.value)} placeholder="Cole o código do treino aqui" className="w-full bg-neutral-800 p-4 rounded-xl mb-4 text-white font-mono text-center uppercase" />
+                        <input value={importCode} onChange={e => setImportCode(e.target.value)} placeholder="Cole o código do treino aqui" className="w-full bg-neutral-800 p-4 rounded-xl mb-4 text-white font-mono text-center uppercase"  aria-label="Cole o código do treino aqui"/>
                         <div className="flex gap-2">
                             <button onClick={() => setShowImportModal(false)} className="flex-1 p-3 bg-neutral-800 rounded-xl font-bold text-neutral-400">Cancelar</button>
                             <button onClick={handleImportWorkout} className="flex-1 p-3 bg-blue-600 rounded-xl font-bold text-white">Importar</button>
@@ -237,7 +237,7 @@ export default function DashboardModals(props: DashboardModalsProps) {
                         <p className="text-neutral-400 text-sm mb-6">Selecione o arquivo .json que você salvou anteriormente.</p>
                         <label className="block w-full cursor-pointer bg-blue-600 hover:bg-blue-500 text-white font-bold py-4 rounded-xl transition-colors">
                             Selecionar Arquivo
-                            <input type="file" accept=".json" onChange={handleJsonUpload} className="hidden" />
+                            <input type="file" accept=".json" onChange={handleJsonUpload} className="hidden" aria-label="Selecionar arquivo de backup JSON" />
                         </label>
                         <button onClick={() => setShowJsonImportModal(false)} className="mt-4 text-neutral-500 text-sm hover:text-white">Cancelar</button>
                     </div>
@@ -622,7 +622,7 @@ export default function DashboardModals(props: DashboardModalsProps) {
                                         value={String((preCheckinDraft as Record<string, unknown>)?.weight ?? '')}
                                         onChange={(e) => setPreCheckinDraft({ ...(preCheckinDraft || {}), weight: e.target.value })}
                                         className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-yellow-500"
-                                    />
+                                     aria-label="Ex: 85.0"/>
                                     <p className="mt-1.5 text-[11px] text-yellow-500/70 leading-snug">
                                         ⚡ Preencher melhora a precisão do gasto calórico no relatório final.
                                     </p>

--- a/src/app/(app)/dashboard/schedule/ScheduleClient.tsx
+++ b/src/app/(app)/dashboard/schedule/ScheduleClient.tsx
@@ -388,6 +388,7 @@ export default function SchedulePage() {
                 value={selectedDate}
                 onChange={e => setSelectedDate(e.target.value)}
                 className="bg-neutral-900 border border-neutral-700 rounded-xl px-3 py-3 text-sm text-white focus:outline-none focus:border-yellow-500 min-h-[48px] w-full"
+                aria-label="Data"
               />
             </div>
             <button
@@ -502,6 +503,7 @@ export default function SchedulePage() {
                       value={form.date}
                       onChange={e => setForm(prev => ({ ...prev, date: e.target.value }))}
                       className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-3 py-2 text-sm text-white focus:outline-none focus:border-yellow-500 min-h-[44px]"
+                      aria-label="Data do agendamento"
                     />
                   </div>
                   <div className="space-y-1">
@@ -511,6 +513,7 @@ export default function SchedulePage() {
                       value={form.startTime}
                       onChange={e => setForm(prev => ({ ...prev, startTime: e.target.value }))}
                       className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-3 py-2 text-sm text-white focus:outline-none focus:border-yellow-500 min-h-[44px]"
+                      aria-label="Hora de início"
                     />
                   </div>
                 </div>
@@ -521,6 +524,7 @@ export default function SchedulePage() {
                     value={form.endTime}
                     onChange={e => setForm(prev => ({ ...prev, endTime: e.target.value }))}
                     className="w-full bg-neutral-800 border border-neutral-700 rounded-xl px-3 py-2 text-sm text-white focus:outline-none focus:border-yellow-500 min-h-[44px]"
+                    aria-label="Hora de fim"
                   />
                 </div>
                 <div className="space-y-1">

--- a/src/app/marketplace/MarketplaceClient.tsx
+++ b/src/app/marketplace/MarketplaceClient.tsx
@@ -668,19 +668,19 @@ export default function MarketplaceClient() {
                       placeholder="Nome completo"
                       value={payerName}
                       onChange={(e) => setPayerName(e.target.value)}
-                    />
+                     aria-label="Nome completo"/>
                     <input
                       className="w-full rounded-xl bg-neutral-950 border border-neutral-800 px-4 py-3 text-white font-medium focus:outline-none focus:border-yellow-500 transition-colors"
                       placeholder="Celular (DDD + número)"
                       value={mobilePhone}
                       onChange={(e) => setMobilePhone(e.target.value)}
-                    />
+                     aria-label="Celular (DDD + número)"/>
                     <input
                       className="w-full rounded-xl bg-neutral-950 border border-neutral-800 px-4 py-3 text-white font-medium focus:outline-none focus:border-yellow-500 transition-colors"
                       placeholder="CPF ou CNPJ"
                       value={cpfCnpj}
                       onChange={(e) => setCpfCnpj(e.target.value)}
-                    />
+                     aria-label="CPF ou CNPJ"/>
                   </div>
 
                   <div className="space-y-3 pt-2">

--- a/src/components/CoachChatModal.tsx
+++ b/src/components/CoachChatModal.tsx
@@ -390,7 +390,7 @@ export default function CoachChatModal({
                                 className="flex-1 rounded-xl px-4 py-3 text-white placeholder:text-neutral-500 focus:outline-none transition-all"
                                 style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
                                 disabled={isLoading}
-                            />
+                             aria-label="Digite sua mensagem..."/>
                             <button
                                 onClick={handleSend}
                                 disabled={!input.trim() || isLoading}

--- a/src/components/ProgressPhotos.tsx
+++ b/src/components/ProgressPhotos.tsx
@@ -243,7 +243,6 @@ function UploadModal({ onClose, onUploaded }: UploadModalProps) {
             </button>
           )}
 
-          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <input
             ref={fileRef}
             type="file"
@@ -251,6 +250,7 @@ function UploadModal({ onClose, onUploaded }: UploadModalProps) {
             capture="environment"
             className="hidden"
             onChange={handleChange}
+            aria-label="Selecionar foto de progresso"
           />
 
           {/* Kind selector */}

--- a/src/components/assessment/AssessmentButton.tsx
+++ b/src/components/assessment/AssessmentButton.tsx
@@ -320,6 +320,7 @@ export default function AssessmentButton({
             accept="application/json"
             className="hidden"
             onChange={handleImportFileChange}
+            aria-label="Importar arquivo JSON de avaliação"
           />
           {!isIosNativeApp ? (
             <input
@@ -329,6 +330,7 @@ export default function AssessmentButton({
               multiple
               className="hidden"
               onChange={handleScanFileChange}
+              aria-label="Escanear avaliação (foto ou PDF)"
             />
           ) : null}
         </div>
@@ -397,6 +399,7 @@ export default function AssessmentButton({
           multiple
           className="hidden"
           onChange={handleScanFileChange}
+          aria-label="Escanear avaliação (foto ou PDF)"
         />
       ) : null}
     </div>

--- a/src/components/assessment/AssessmentHeader.tsx
+++ b/src/components/assessment/AssessmentHeader.tsx
@@ -105,6 +105,7 @@ export const AssessmentHeader = ({
               multiple
               className="hidden"
               onChange={onScanFileChange}
+              aria-label="Escanear avaliação (foto ou PDF)"
             />
           ) : null}
         </div>

--- a/src/components/workout/Modals.tsx
+++ b/src/components/workout/Modals.tsx
@@ -750,7 +750,7 @@ export default function Modals() {
                       }}
                       placeholder="Total reps (ex.: 12)"
                       className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                    />
+                     aria-label="Total reps (ex.: 12)"/>
                     <input
                       inputMode="decimal"
                       value={String((((clusterModal as UnknownRecord | null)?.planned as UnknownRecord | null)?.cluster_blocks_count ?? '') as unknown)}
@@ -764,7 +764,7 @@ export default function Modals() {
                       }}
                       placeholder="Blocos (ex.: 3)"
                       className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                    />
+                     aria-label="Blocos (ex.: 3)"/>
                     <input
                       inputMode="decimal"
                       value={String((((clusterModal as UnknownRecord | null)?.planned as UnknownRecord | null)?.intra_rest_sec ?? (clusterModal as UnknownRecord | null)?.intra ?? '') as unknown)}
@@ -778,7 +778,7 @@ export default function Modals() {
                       }}
                       placeholder="Descanso (s) (ex.: 15)"
                       className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                    />
+                     aria-label="Descanso (s) (ex.: 15)"/>
                   </div>
                   <div className="mt-2 flex items-center justify-end">
                     <button
@@ -868,7 +868,7 @@ export default function Modals() {
                           }}
                           placeholder="kg"
                           className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                        />
+                         aria-label="kg"/>
                         <input
                           inputMode="decimal"
                           value={repsValue}
@@ -891,7 +891,7 @@ export default function Modals() {
                           }}
                           placeholder="reps"
                           className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                        />
+                         aria-label="reps"/>
                       </div>
                       {!isLast ? <div className="mt-2 text-xs text-neutral-500">Descanso: {safeRestSec}s</div> : null}
                     </div>
@@ -909,7 +909,7 @@ export default function Modals() {
                   }}
                   placeholder="RPE (0-10)"
                   className="mt-2 w-full bg-black/30 border border-yellow-500/30 rounded-lg px-3 py-2 text-sm text-yellow-500 font-bold outline-none focus:ring-1 ring-yellow-500"
-                />
+                 aria-label="RPE (0-10)"/>
               </div>
             </div>
 

--- a/src/components/workout/ModalsComplexMethods.tsx
+++ b/src/components/workout/ModalsComplexMethods.tsx
@@ -1,5 +1,5 @@
 'use client';
-/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/control-has-associated-label */
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 
 import React from 'react';
 import { Check, Clock, Save, X } from 'lucide-react';
@@ -87,7 +87,7 @@ export function ModalsComplexMethods() {
                                         }}
                                         placeholder="Minis (ex.: 2)"
                                         className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                    />
+                                     aria-label="Minis (ex.: 2)"/>
                                     <input
                                         inputMode="decimal"
                                         value={String(restPauseModal?.pauseSec ?? '')}
@@ -97,7 +97,7 @@ export function ModalsComplexMethods() {
                                         }}
                                         placeholder="Descanso (s) (ex.: 15)"
                                         className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                    />
+                                     aria-label="Descanso (s) (ex.: 15)"/>
                                     <input
                                         inputMode="decimal"
                                         value={String(restPauseModal?.weight ?? '')}
@@ -107,7 +107,7 @@ export function ModalsComplexMethods() {
                                         }}
                                         placeholder="kg"
                                         className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                    />
+                                     aria-label="kg"/>
                                 </div>
                                 <div className="mt-2 flex items-center justify-end">
                                     <button
@@ -176,7 +176,7 @@ export function ModalsComplexMethods() {
                                                     }}
                                                     placeholder="kg"
                                                     className="w-full bg-black/30 border border-neutral-700 rounded-xl px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                                />
+                                                 aria-label="kg"/>
                                                 <input
                                                     inputMode="decimal"
                                                     value={mini == null ? '' : String(mini)}
@@ -192,7 +192,7 @@ export function ModalsComplexMethods() {
                                                     }}
                                                     placeholder="reps"
                                                     className="w-full bg-black/30 border border-neutral-700 rounded-xl px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                                />
+                                                 aria-label="reps"/>
                                             </div>
                                             {!isLast && safeRestSec ? <div className="mt-2 text-xs text-neutral-500">Descanso: {safeRestSec}s</div> : null}
                                         </div>
@@ -210,7 +210,7 @@ export function ModalsComplexMethods() {
                                     }}
                                     placeholder="RPE (0-10)"
                                     className="mt-2 w-full bg-black/30 border border-yellow-500/30 rounded-xl px-3 py-2 text-sm text-yellow-500 font-bold outline-none focus:ring-1 ring-yellow-500"
-                                />
+                                 aria-label="RPE (0-10)"/>
                             </div>
                         </div>
 
@@ -302,6 +302,7 @@ export function ModalsComplexMethods() {
                                                             });
                                                         }}
                                                         placeholder={weightPlaceholder}
+                                                        aria-label={`Peso da etapa ${idx + 1}`}
                                                         className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
                                                     />
                                                     <input
@@ -319,6 +320,7 @@ export function ModalsComplexMethods() {
                                                             });
                                                         }}
                                                         placeholder={repsPlaceholder}
+                                                        aria-label={`Repetições da etapa ${idx + 1}`}
                                                         className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
                                                     />
                                                 </div>
@@ -375,8 +377,8 @@ export function ModalsComplexMethods() {
                                     <div key={idx} className="rounded-xl bg-neutral-800/60 border border-neutral-700 p-3 space-y-2">
                                         <div className="text-xs font-black uppercase tracking-widest text-neutral-400">Etapa {idx + 1}</div>
                                         <div className="grid grid-cols-2 gap-2">
-                                            <input inputMode="decimal" value={String(s?.weight ?? '')} onChange={(e) => setStrippingModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.stages as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, weight: e?.target?.value ?? '' }; return { ...prev, stages: list, error: '' }; })} placeholder="Peso (kg)" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
-                                            <input inputMode="decimal" value={s?.reps != null ? String(s.reps) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setStrippingModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.stages as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, reps: n != null && n > 0 ? n : null }; return { ...prev, stages: list, error: '' }; }); }} placeholder="Reps" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                            <input inputMode="decimal" value={String(s?.weight ?? '')} onChange={(e) => setStrippingModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.stages as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, weight: e?.target?.value ?? '' }; return { ...prev, stages: list, error: '' }; })} placeholder="Peso (kg)" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="Peso (kg)"/>
+                                            <input inputMode="decimal" value={s?.reps != null ? String(s.reps) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setStrippingModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.stages as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, reps: n != null && n > 0 ? n : null }; return { ...prev, stages: list, error: '' }; }); }} placeholder="Reps" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="Reps"/>
                                         </div>
                                     </div>
                                 ))}
@@ -424,8 +426,8 @@ export function ModalsComplexMethods() {
                                             {idx < blocks.length - 1 && <div className="text-[10px] text-neutral-500 inline-flex items-center gap-1"><Clock size={10} />{intraSec}s descanso</div>}
                                         </div>
                                         <div className="grid grid-cols-2 gap-2">
-                                            <input inputMode="decimal" value={String(b?.weight ?? '')} onChange={(e) => setFst7Modal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.blocks as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, weight: e?.target?.value ?? '' }; return { ...prev, blocks: list, error: '' }; })} placeholder="Peso (kg)" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
-                                            <input inputMode="decimal" value={b?.reps != null ? String(b.reps) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setFst7Modal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.blocks as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, reps: n != null && n > 0 ? n : null }; return { ...prev, blocks: list, error: '' }; }); }} placeholder="Reps" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                            <input inputMode="decimal" value={String(b?.weight ?? '')} onChange={(e) => setFst7Modal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.blocks as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, weight: e?.target?.value ?? '' }; return { ...prev, blocks: list, error: '' }; })} placeholder="Peso (kg)" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="Peso (kg)"/>
+                                            <input inputMode="decimal" value={b?.reps != null ? String(b.reps) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setFst7Modal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.blocks as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, reps: n != null && n > 0 ? n : null }; return { ...prev, blocks: list, error: '' }; }); }} placeholder="Reps" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="Reps"/>
                                         </div>
                                     </div>
                                 ))}
@@ -460,7 +462,7 @@ export function ModalsComplexMethods() {
                                 <div className="grid grid-cols-2 gap-3">
                                     <div className="space-y-1">
                                         <div className="text-xs font-black uppercase tracking-widest text-neutral-400">Peso base (kg)</div>
-                                        <input inputMode="decimal" value={String(waveModal.weight ?? '')} onChange={(e) => setWaveModal((prev) => prev && typeof prev === 'object' ? { ...prev, weight: e?.target?.value ?? '', error: '' } : prev)} placeholder="Ex: 80" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                        <input inputMode="decimal" value={String(waveModal.weight ?? '')} onChange={(e) => setWaveModal((prev) => prev && typeof prev === 'object' ? { ...prev, weight: e?.target?.value ?? '', error: '' } : prev)} placeholder="Ex: 80" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="Ex: 80"/>
                                     </div>
                                     <div className="space-y-1">
                                         <div className="text-xs font-black uppercase tracking-widest text-neutral-400">Nº de ondas</div>
@@ -477,22 +479,22 @@ export function ModalsComplexMethods() {
                                         <div className="grid grid-cols-3 gap-2">
                                             <div className="space-y-1">
                                                 <div className="text-[10px] text-neutral-500 uppercase tracking-widest">Pesado (reps)</div>
-                                                <input inputMode="numeric" value={w?.heavy != null ? String(w.heavy) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, heavy: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="3" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                                <input inputMode="numeric" value={w?.heavy != null ? String(w.heavy) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, heavy: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="3" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="3"/>
                                             </div>
                                             <div className="space-y-1">
                                                 <div className="text-[10px] text-neutral-500 uppercase tracking-widest">Médio (reps)</div>
-                                                <input inputMode="numeric" value={w?.medium != null ? String(w.medium) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, medium: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="5" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                                <input inputMode="numeric" value={w?.medium != null ? String(w.medium) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, medium: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="5" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="5"/>
                                             </div>
                                             <div className="space-y-1">
                                                 <div className="text-[10px] text-neutral-500 uppercase tracking-widest">Ultra leve (reps)</div>
-                                                <input inputMode="numeric" value={w?.ultra != null ? String(w.ultra) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, ultra: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="2" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                                <input inputMode="numeric" value={w?.ultra != null ? String(w.ultra) : ''} onChange={(e) => { const n = parseTrainingNumber(e?.target?.value); setWaveModal((prev) => { if (!prev || typeof prev !== 'object') return prev; const list = [...(prev.waves as unknown[])]; const cur = (list[idx] && typeof list[idx] === 'object' ? list[idx] : {}) as UnknownRecord; list[idx] = { ...cur, ultra: n != null ? n : null }; return { ...prev, waves: list, error: '' }; }); }} placeholder="2" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-2 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="2"/>
                                             </div>
                                         </div>
                                     </div>
                                 ))}
                                 <div className="space-y-1">
                                     <div className="text-xs font-black uppercase tracking-widest text-neutral-400">RPE (opcional)</div>
-                                    <input inputMode="decimal" value={String(waveModal.rpe ?? '')} onChange={(e) => setWaveModal((prev) => prev && typeof prev === 'object' ? { ...prev, rpe: e?.target?.value ?? '' } : prev)} placeholder="1–10" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500" />
+                                    <input inputMode="decimal" value={String(waveModal.rpe ?? '')} onChange={(e) => setWaveModal((prev) => prev && typeof prev === 'object' ? { ...prev, rpe: e?.target?.value ?? '' } : prev)} placeholder="1–10" className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"  aria-label="1–10"/>
                                 </div>
                             </div>
                             <div className="p-4 border-t border-neutral-800 flex items-center justify-between gap-2">
@@ -581,7 +583,7 @@ export function ModalsComplexMethods() {
                                             }}
                                             placeholder="Total reps (ex.: 12)"
                                             className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                        />
+                                         aria-label="Total reps (ex.: 12)"/>
                                         <input
                                             inputMode="decimal"
                                             value={String((((clusterModal as UnknownRecord | null)?.planned as UnknownRecord | null)?.cluster_blocks_count ?? '') as unknown)}
@@ -595,7 +597,7 @@ export function ModalsComplexMethods() {
                                             }}
                                             placeholder="Blocos (ex.: 3)"
                                             className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                        />
+                                         aria-label="Blocos (ex.: 3)"/>
                                         <input
                                             inputMode="decimal"
                                             value={String((((clusterModal as UnknownRecord | null)?.planned as UnknownRecord | null)?.intra_rest_sec ?? (clusterModal as UnknownRecord | null)?.intra ?? '') as unknown)}
@@ -609,7 +611,7 @@ export function ModalsComplexMethods() {
                                             }}
                                             placeholder="Descanso (s) (ex.: 15)"
                                             className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                        />
+                                         aria-label="Descanso (s) (ex.: 15)"/>
                                     </div>
                                     <div className="mt-2 flex items-center justify-end">
                                         <button
@@ -708,7 +710,7 @@ export function ModalsComplexMethods() {
                                                     }}
                                                     placeholder="kg"
                                                     className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                                />
+                                                 aria-label="kg"/>
                                                 <input
                                                     inputMode="decimal"
                                                     value={repsValue}
@@ -731,7 +733,7 @@ export function ModalsComplexMethods() {
                                                     }}
                                                     placeholder="reps"
                                                     className="w-full bg-black/30 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
-                                                />
+                                                 aria-label="reps"/>
                                             </div>
                                             {!isLast ? <div className="mt-2 text-xs text-neutral-500">Descanso: {safeRestSec}s</div> : null}
                                         </div>
@@ -749,7 +751,7 @@ export function ModalsComplexMethods() {
                                     }}
                                     placeholder="RPE (0-10)"
                                     className="mt-2 w-full bg-black/30 border border-yellow-500/30 rounded-lg px-3 py-2 text-sm text-yellow-500 font-bold outline-none focus:ring-1 ring-yellow-500"
-                                />
+                                 aria-label="RPE (0-10)"/>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- **Adiciona `aria-label` em 46 `<input>`** distribuídos em 9 arquivos (modais de drop-set, rest-pause, cluster, FST-7, wave; date/time pickers; file inputs ocultos).
- **Conserta o `scan-a11y.mjs`**: substitui o regex que pegava o primeiro `>` (geralmente o `=>` de uma arrow function) por um walker ciente de chaves JSX. Esse bug gerava ~19 falsos positivos.
- Remove um `eslint-disable jsx-a11y/control-has-associated-label` que ficou obsoleto.

## Como derivei os labels
- Quando o input tinha `placeholder="..."` com string literal, o valor virou o `aria-label` (auto-fixado por script seguro que insere antes do `>` final).
- Quando o `placeholder` era expressão JSX (`{weightPlaceholder}`), entrou label contextual (`Peso da etapa ${idx + 1}`).
- Inputs `type="file" hidden` ganharam label baseado no botão visível que dispara o picker.
- Date/time pickers usaram o texto do `<label>` adjacente.

## Test plan
- [x] `node scripts/scan-a11y.mjs` → 0 issues de input (antes: 65 reportados, 46 reais)
- [x] `npx tsc --noEmit` → 0 erros
- [x] ESLint nos 9 arquivos modificados → 0 warnings
- [x] `npm run test:unit` → 1248/1248 passando
- [ ] Smoke test visual nos modais de método complexo (drop-set, rest-pause, cluster) para garantir que o `aria-label` não muda o layout

https://claude.ai/code/session_01D47hidg9EBy5N47qg9MvdU