### PR TITLE
refactor(workout-report): extract ReportCelebrationSplash (-40 lines)

### DIFF
--- a/src/components/WorkoutReport.tsx
+++ b/src/components/WorkoutReport.tsx
@@ -24,6 +24,7 @@ import { ReportHighlightsPanel } from '@/components/workout-report/ReportHighlig
 import { ReportExerciseTable } from '@/components/workout-report/ReportExerciseTable'
 import { ReportTeamSection } from '@/components/workout-report/ReportTeamSection'
 import { ReportTimePanel } from '@/components/workout-report/ReportTimePanel'
+import { ReportCelebrationSplash } from '@/components/workout-report/ReportCelebrationSplash'
 
 /** Skeleton placeholder for lazy-loaded report sections */
 const SectionSkeleton = () => (
@@ -551,48 +552,7 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
         <div className="fixed inset-0 z-[1000] bg-neutral-950 text-white overflow-y-auto overflow-x-hidden">
             {/* 8.1 — Celebration Splash Overlay */}
             {showSplash && (
-                <button
-                    type="button"
-                    className="fixed inset-0 z-[1200] flex flex-col items-end justify-end bg-neutral-950 overflow-hidden w-full border-0 p-0 text-left"
-                    onClick={() => setShowSplash(false)}
-                >
-                    {/* Victory hero — full screen background */}
-                    <div className="absolute inset-0">
-                        <NextImage
-                            src="/report-victory.png"
-                            alt=""
-                            fill
-                            priority
-                            unoptimized
-                            className="object-cover object-center"
-                        />
-                        {/* Bottom gradient so text is readable */}
-                        <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/50 to-neutral-950/20" />
-                        {/* Top vignette */}
-                        <div className="absolute inset-0 bg-gradient-to-b from-neutral-950/70 via-transparent to-transparent" />
-                    </div>
-
-                    {/* Content — pinned to bottom */}
-                    <div className="relative z-10 w-full px-6 pb-16 flex flex-col items-center text-center gap-3">
-                        <div className="text-[10px] font-black uppercase tracking-[0.3em] text-yellow-500">IronTracks</div>
-                        <div className="text-4xl sm:text-5xl font-black uppercase tracking-tight text-white leading-tight">
-                            Treino Finalizado!
-                        </div>
-                        <div className="text-base font-black text-yellow-400 max-w-xs truncate">
-                            {String(safeSession?.workoutTitle || '')}
-                        </div>
-                        {Number(safeSession?.totalTime) > 0 && (
-                            <div className="flex items-center gap-2 px-4 py-2 rounded-full mt-1"
-                                style={{ background: 'rgba(234,179,8,0.12)', border: '1px solid rgba(234,179,8,0.3)' }}>
-                                <span className="text-xl font-black text-white">
-                                    {Math.floor(Number(safeSession?.totalTime ?? 0) / 60)}min
-                                </span>
-                                <span className="text-[10px] font-black uppercase text-yellow-500">duração</span>
-                            </div>
-                        )}
-                        <div className="mt-3 text-xs font-bold text-neutral-400">Toque para ver o relatório</div>
-                    </div>
-                </button>
+                <ReportCelebrationSplash safeSession={safeSession} onDismiss={() => setShowSplash(false)} />
             )}
             {/* Fixed header bar */}
             <div className={`fixed top-0 left-0 right-0 z-[1100] no-print bg-neutral-950/95 backdrop-blur border-b border-neutral-800/80 px-3 md:px-6 pt-safe pb-1.5 ${isGenerating ? 'opacity-50 pointer-events-none' : ''}`}>

--- a/src/components/workout-report/ReportCelebrationSplash.tsx
+++ b/src/components/workout-report/ReportCelebrationSplash.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import NextImage from 'next/image'
+
+type AnyObj = Record<string, unknown>
+
+interface ReportCelebrationSplashProps {
+    safeSession: AnyObj | null
+    onDismiss: () => void
+}
+
+export const ReportCelebrationSplash = ({ safeSession, onDismiss }: ReportCelebrationSplashProps) => (
+    <button
+        type="button"
+        className="fixed inset-0 z-[1200] flex flex-col items-end justify-end bg-neutral-950 overflow-hidden w-full border-0 p-0 text-left"
+        onClick={onDismiss}
+    >
+        {/* Victory hero — full screen background */}
+        <div className="absolute inset-0">
+            <NextImage
+                src="/report-victory.png"
+                alt=""
+                fill
+                priority
+                unoptimized
+                className="object-cover object-center"
+            />
+            {/* Bottom gradient so text is readable */}
+            <div className="absolute inset-0 bg-gradient-to-t from-neutral-950 via-neutral-950/50 to-neutral-950/20" />
+            {/* Top vignette */}
+            <div className="absolute inset-0 bg-gradient-to-b from-neutral-950/70 via-transparent to-transparent" />
+        </div>
+
+        {/* Content — pinned to bottom */}
+        <div className="relative z-10 w-full px-6 pb-16 flex flex-col items-center text-center gap-3">
+            <div className="text-[10px] font-black uppercase tracking-[0.3em] text-yellow-500">IronTracks</div>
+            <div className="text-4xl sm:text-5xl font-black uppercase tracking-tight text-white leading-tight">
+                Treino Finalizado!
+            </div>
+            <div className="text-base font-black text-yellow-400 max-w-xs truncate">
+                {String(safeSession?.workoutTitle || '')}
+            </div>
+            {Number(safeSession?.totalTime) > 0 && (
+                <div className="flex items-center gap-2 px-4 py-2 rounded-full mt-1"
+                    style={{ background: 'rgba(234,179,8,0.12)', border: '1px solid rgba(234,179,8,0.3)' }}>
+                    <span className="text-xl font-black text-white">
+                        {Math.floor(Number(safeSession?.totalTime ?? 0) / 60)}min
+                    </span>
+                    <span className="text-[10px] font-black uppercase text-yellow-500">duração</span>
+                </div>
+            )}
+            <div className="mt-3 text-xs font-bold text-neutral-400">Toque para ver o relatório</div>
+        </div>
+    </button>
+)


### PR DESCRIPTION
## Resumo

Segundo passo do refactor dos 3 componentes gigantes. Extraí o overlay de celebração pós-treino do `WorkoutReport.tsx` para um componente dedicado.

**Mudança mecânica, sem alteração de comportamento:**

- `WorkoutReport.tsx`: 899 → 859 linhas (-40)
- Novo: `src/components/workout-report/ReportCelebrationSplash.tsx` (55 linhas)
- Segue o pattern já existente da pasta `workout-report/` (ReportMetricsPanel, ReportSummaryCards, etc.)
- 2 props: `safeSession`, `onDismiss`

## Por que apenas o Splash

Handlers complexos do `WorkoutReport` (`handleDownloadPDF` 124 linhas, `handleShare`, `handleGenerateAi`, `handlePartnerPlan`) dependem de muitas closures locais (aiState, session, settings, postCheckin, etc.) — extrair exigiria refactor arquitetural (custom hook), merece PR dedicada com design cuidadoso. Esta PR mantém escopo seguro.

## Validação

- [x] `npx tsc --noEmit` → 0 errors
- [x] ESLint → 0 warnings
- [ ] **Precisa validação visual**: finalizar treino → confirmar que splash de celebração aparece idêntico (imagem victory bg, gradientes, "Treino Finalizado!", duração, tap para dismiss)

## Test plan

- [ ] Finalizar um treino → overlay de celebração aparece
- [ ] Imagem `/report-victory.png` carrega
- [ ] Título do treino e duração (min) aparecem
- [ ] Tap em qualquer lugar da tela fecha o splash