### PR TITLE
cleanup: remove 5 dead-code references to deleted chat_channels system

### DIFF
--- a/src/actions/admin-actions.ts
+++ b/src/actions/admin-actions.ts
@@ -488,8 +488,7 @@ export async function exportAllData(): Promise<AdminResult & { data?: unknown }>
         const { data: students } = await adminDb.from('students').select('*').limit(2000)
         const { data: assessments } = await adminDb.from('assessments').select('*').limit(2000)
         const { data: notifications } = await adminDb.from('notifications').select('*').limit(5000)
-        const { data: chat_channels } = await adminDb.from('chat_channels').select('*').limit(1000)
-        const { data: messages } = await adminDb.from('messages').select('*').limit(5000)
+        // chat_channels + messages removed — dead system deleted in 20260419200000
         const { data: invites } = await adminDb.from('invites').select('*').limit(1000)
         const { data: team_sessions } = await adminDb.from('team_sessions').select('*').limit(1000)
 
@@ -506,8 +505,6 @@ export async function exportAllData(): Promise<AdminResult & { data?: unknown }>
             students: students || [],
             assessments: assessments || [],
             notifications: notifications || [],
-            chat_channels: chat_channels || [],
-            messages: messages || [],
             invites: invites || [],
             team_sessions: team_sessions || [],
             workouts: (Array.isArray(workouts) ? workouts : []).map((w: Record<string, unknown>) => ({
@@ -562,22 +559,12 @@ export async function importAllData(json: Record<string, unknown>): Promise<Admi
         const students = toRows(json?.students)
         const assessments = toRows(json?.assessments)
         const notifications = toRows(json?.notifications)
-        const chat_channels = toRows(json?.chat_channels)
-        const messages = toRows(json?.messages)
         const invites = toRows(json?.invites)
         const team_sessions = toRows(json?.team_sessions)
         const workouts = Array.isArray(json?.workouts) ? (json.workouts as AnyRow[]) : []
 
         const totalRecords = profiles.length + teachers.length + students.length + assessments.length + workouts.length
         if (totalRecords === 0) return { error: 'Nenhum dado válido encontrado no arquivo de importação.' }
-
-        if (chat_channels.length) {
-            const batchSize = 500
-            for (let i = 0; i < chat_channels.length; i += batchSize) {
-                const batch = chat_channels.slice(i, i + batchSize)
-                await adminDb.from('chat_channels').upsert(batch, { onConflict: 'id' })
-            }
-        }
 
         if (team_sessions.length) {
             const batchSize = 500
@@ -772,14 +759,6 @@ export async function importAllData(json: Record<string, unknown>): Promise<Admi
             for (let i = 0; i < notifications.length; i += batchSize) {
                 const batch = notifications.slice(i, i + batchSize)
                 await adminDb.from('notifications').upsert(batch, { onConflict: 'id' })
-            }
-        }
-
-        if (messages.length) {
-            const batchSize = 500
-            for (let i = 0; i < messages.length; i += batchSize) {
-                const batch = messages.slice(i, i + batchSize)
-                await adminDb.from('messages').upsert(batch, { onConflict: 'id' })
             }
         }
 

--- a/src/app/api/cron/cleanup-expired/route.ts
+++ b/src/app/api/cron/cleanup-expired/route.ts
@@ -64,7 +64,6 @@ export async function GET(req: Request) {
     ok: true,
     cutoffIso,
     stories: { expired: 0, storageRemoved: 0, deletedRows: 0 },
-    chat: { expiredMessages: 0, storageRemoved: 0, deletedRows: 0 },
     direct: { expiredMessages: 0, storageRemoved: 0, deletedRows: 0 },
   }
 
@@ -97,7 +96,9 @@ export async function GET(req: Request) {
     metadata: { cutoffIso, deleted: result.stories.deletedRows },
   })
 
-  const cleanupChatTable = async (table: 'messages' | 'direct_messages', bucket: 'chat-media') => {
+  // Cleanup only runs on direct_messages — the old `messages` table was
+  // deleted in migration 20260419200000 (chat_channels dead system removed).
+  const cleanupChatTable = async (table: 'direct_messages', bucket: 'chat-media') => {
     const { data: rows, error: selErr } = await admin
       .from(table)
       .select('id, content, created_at')
@@ -130,27 +131,20 @@ export async function GET(req: Request) {
     if (paths.length) {
       for (const part of chunk(Array.from(new Set(paths)), 100)) {
         const { data } = await admin.storage.from(bucket).remove(part)
-        const removed = Array.isArray(data) ? data.length : 0
-        if (table === 'messages') result.chat.storageRemoved += removed
-        else result.direct.storageRemoved += removed
+        result.direct.storageRemoved += Array.isArray(data) ? data.length : 0
       }
     }
 
     if (ids.length) {
       for (const part of chunk(ids, 100)) {
         const { error } = await admin.from(table).delete().in('id', part)
-        if (!error) {
-          if (table === 'messages') result.chat.deletedRows += part.length
-          else result.direct.deletedRows += part.length
-        }
+        if (!error) result.direct.deletedRows += part.length
       }
     }
 
-    if (table === 'messages') result.chat.expiredMessages += ids.length
-    else result.direct.expiredMessages += ids.length
+    result.direct.expiredMessages += ids.length
   }
 
-  await cleanupChatTable('messages', 'chat-media')
   await cleanupChatTable('direct_messages', 'chat-media')
 
   await admin.from('audit_events').insert({
@@ -159,7 +153,6 @@ export async function GET(req: Request) {
     entity_type: 'cron',
     metadata: {
       cutoffIso,
-      messagesDeleted: result.chat.deletedRows,
       directDeleted: result.direct.deletedRows,
     },
   })

--- a/src/components/HeaderActionsMenu.tsx
+++ b/src/components/HeaderActionsMenu.tsx
@@ -12,7 +12,6 @@ import {
   LogOut,
   MessageSquare,
   Sparkles,
-  Users,
   Crown,
 } from 'lucide-react'
 import { isIosNative } from '@/utils/platform'
@@ -30,7 +29,6 @@ interface HeaderActionsMenuProps {
   onAddStory?: () => void       // ← opens story creator on long press
   onOpenAdmin?: () => void
   onOpenChatList?: () => void
-  onOpenGlobalChat?: () => void
   onOpenHistory?: () => void
   onOpenNotifications?: () => void
   onLogout?: () => void
@@ -127,7 +125,6 @@ export default function HeaderActionsMenu({
   onAddStory,
   onOpenAdmin,
   onOpenChatList,
-  onOpenGlobalChat,
   onOpenHistory,
   onOpenNotifications,
   onLogout,
@@ -379,11 +376,6 @@ export default function HeaderActionsMenu({
                   ) : undefined
                 }
                 onClick={() => { onOpenChatList?.(); close() }}
-              />
-              <MenuItem
-                icon={<Users size={14} className="text-neutral-400" />}
-                label="Iron Lounge"
-                onClick={() => { onOpenGlobalChat?.(); close() }}
               />
 
               <Divider />

--- a/src/utils/auth/route.ts
+++ b/src/utils/auth/route.ts
@@ -160,10 +160,8 @@ export async function canUploadToChatMediaPath(userId: string, channelId: string
     if (direct?.id) return true
   } catch (e) { logError('canUploadToChatMediaPath.directChannel', e) }
 
-  try {
-    const { data: member } = await admin.from('chat_members').select('id').eq('channel_id', cid).eq('user_id', uid).maybeSingle()
-    if (member?.id) return true
-  } catch (e) { logError('canUploadToChatMediaPath.chatMember', e) }
+  // chat_members fallback removed — the chat_channels system was deleted in
+  // migration 20260419200000. The only active chat uses direct_channels.
 
   return false
 }

--- a/src/utils/tourSteps.ts
+++ b/src/utils/tourSteps.ts
@@ -54,7 +54,7 @@ const BASE_STEPS: TourStep[] = [
 const COMMUNITY_STEP: TourStep = {
   id: 'community',
   emoji: '🤝',
-  title: 'Iron Lounge',
+  title: 'Comunidade',
   body: 'Conecte-se com outros atletas. Curta conquistas, troque experiências e faça parte de uma comunidade de alta performance.',
 }
 


### PR DESCRIPTION
Pente-fino pós-sessão limpou 5 call sites que ainda referenciam tabelas removidas no #78. Typecheck + eslint + 17/17 smoke. Detalhes no commit.