### PR TITLE
fix(unilateral): preserve flag in mapper + count sets correctly in report

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,446 @@
+# IronTracks — Inventário UI/UX
+
+> Documento técnico do estado atual do design do app, escrito como input para um redesign assistido por Claude Design. **O objetivo é evoluir, não recriar.** O DNA visual (gold + dark + italic black branding) deve ser preservado; tudo o mais (componentes, padrões, tokens) está aberto para refinamento.
+>
+> **Stack:** Next.js 16 · React 19 · TypeScript strict · Tailwind v4 · Capacitor 8 (iOS/Android) · Supabase. App roda em web (Vercel) e mobile híbrido (Capacitor) com a **mesma codebase** — paridade de UX é um requisito, não uma escolha.
+
+---
+
+## 1. Identidade visual e tom
+
+### 1.1 Marca
+- **Wordmark:** `IRONTRACKS` em **italic + font-black (900)**, letterSpacing -0.04em, ~1.7rem em mobile.
+- **Logo:** halter 3D dourado (`/public/header-dumbbell.png`, 32×32 PNG) com `filter: drop-shadow(0 0 6px rgba(245,158,11,0.55))` — glow gold sempre.
+- **Tagline (não visível na UI ainda, está só em metadata):** "SISTEMA DE ALTA PERFORMANCE".
+
+### 1.2 Cor da marca
+**Gold/Amber é a cor principal.** Não é decoração — é a personalidade. Aparece em ~70% dos CTAs, badges, headers, focus states.
+
+```
+Gradient principal:
+linear-gradient(135deg, #f59e0b 0%, #d97706 60%, #b45309 100%)
+
+Glow forte (usado em hover/celebração):
+0 0 40px rgba(234, 179, 8, 0.28)
+```
+
+### 1.3 Tom de voz
+Curto, agressivo, motivacional, premium. Nada de UX writing acolhedor/explicativo demais. Exemplos da copy atual:
+- `Concluído` (não "Você concluiu!")
+- `Iniciar Treino` (não "Vamos lá começar")
+- `PENDENTES`, `OFFLINE`, `SISTEMA` em caps
+- Toast de PR: `TRIPLE PR!` (nada sutil)
+- Badges: `LADO L`, `LADO R`, `NORMAL`, `DROP`, `VIP`
+
+**Princípio para evoluir:** se a copy soar como app de meditação, está errado. O usuário-alvo é alguém que treina pesado e quer feedback imediato e direto.
+
+### 1.4 Modo
+**Dark only.** Não há modo claro. Tentativa de luz única é em PDFs gerados (white background forçado em print stylesheet). Manter dark como única opção é decisão deliberada — mudar isso requer discussão de produto.
+
+---
+
+## 2. Design tokens
+
+### 2.1 Sistema de cores
+
+**Brand (gold/amber) — usar com intenção:**
+| Token | Hex | Uso |
+|---|---|---|
+| `yellow-500` | `#fbbf24` | Primário (CTAs, badges, highlights) |
+| `amber-600` | `#d97706` | Variante mais quente |
+| `amber-400` | `#fbbf24` | Iconografia interativa |
+| Gold gradient | gradient acima | Botão principal "Iniciar Treino", celebração de PR |
+
+**Estados semânticos:**
+| Estado | Cor base | Usado em |
+|---|---|---|
+| Sucesso / concluído | `emerald-500` | Set done, exercício completo, badge ✓ |
+| Aviso / pendente | `yellow-500` | Sync pendente, série não-feita |
+| Erro / destrutivo | `red-500` | "Parar", danger buttons, erros |
+| Informativo / neutro | `blue-500` | Lado L (unilateral), focus rings |
+| Acento secundário | `orange-500` | Lado R (unilateral), warning soft |
+
+**Backgrounds (profundidade):**
+```css
+.bg-depth-0 { background: #0a0a0a; }   /* page base */
+.bg-depth-1 { background: #0f0f0e; }   /* warm black, cards */
+.bg-depth-2 { background: #151514; }   /* elevated cards */
+.bg-depth-3 { background: #1a1a18; }   /* modals, popovers */
+```
+
+**Bordas e divisórias:** `neutral-700` (forte), `neutral-800` (sutil), `neutral-700/80` (com opacidade).
+
+### 2.2 Tipografia
+
+**Família única:** Inter (Google Fonts, swap, var `--font-inter`). Importada em `src/app/layout.tsx:10-19`.
+
+**Pesos em uso:**
+| Peso | Uso |
+|---|---|
+| `font-black` (900) | Wordmark, badges, números grandes (timer), CTAs |
+| `font-bold` (700) | Buttons, títulos secundários |
+| `font-medium` (500) | Raro |
+| `font-normal` (400) | Body text, descrições |
+
+**Escala responsiva (custom utilities em `src/app/globals.css:458-462`):**
+```css
+.text-title-hero  { font-size: clamp(1.75rem, 5vw, 2.5rem); }
+.text-title-lg    { font-size: clamp(1.25rem, 3.5vw, 1.75rem); }
+.text-title-md    { font-size: clamp(1rem, 2.5vw, 1.25rem); }
+.text-title-sm    { font-size: clamp(0.8125rem, 2vw, 0.9375rem); }
+.text-body-lg     { font-size: clamp(0.875rem, 2vw, 1rem); }
+```
+
+**Padrão de label/badge:** uppercase, `tracking-widest` (0.18em–0.25em), `text-[9px]`, `text-[10px]` ou `text-[11px]`. Cor `text-neutral-500` quando inativo, cor temática quando ativo.
+
+### 2.3 Espaçamento e formas
+
+| Categoria | Padrão | Variante |
+|---|---|---|
+| Padding card | `p-3` (12px) ou `p-4` (16px) | `px-2.5 py-2` em rows estreitas |
+| Gap entre cards | `gap-3` (12px) ou `gap-4` (16px) | `space-y-1` em listas densas |
+| Border radius | `rounded-xl` (12px) padrão, `rounded-2xl` (16px) modais | `rounded-full` em pills/badges |
+| Largura mínima toque | 44px (iOS HIG) | `min-h-9` ou `min-h-11` |
+
+### 2.4 Safe areas (Capacitor iOS)
+
+Obrigatório em qualquer container que toque borda:
+```css
+.pt-safe         { padding-top: env(safe-area-inset-top); }
+.pb-safe         { padding-bottom: env(safe-area-inset-bottom); }
+.pb-safe-extra   { padding-bottom: calc(env(safe-area-inset-bottom) + 80px); }
+```
+
+---
+
+## 3. Sistema de componentes
+
+### 3.1 PremiumUI — primitivos de marca
+
+Localização: `src/components/ui/PremiumUI.tsx`. Esses são os blocos de identidade gold:
+
+| Componente | Função |
+|---|---|
+| `<GoldBadge>` | Pill dourada, font-black, 10px tracking |
+| `<GoldGradientBorder>` | Wrapper com `p-[1px]` + gradient border |
+| `<GoldCard>` | Wraps GoldGradientBorder pra cards premium |
+| `<SectionHeader>` | Título + label badge + ícone (padrão de seção) |
+| `<GoldDivider>` | Linha gradient horizontal |
+| `<PremiumButton>` | Variantes: `gold` (CTA principal), `ghost`, `danger`, `subtle` |
+| `<PremiumToggle>` | Switch w-12 h-6 com thumb animado |
+
+Esses são os átomos da identidade. **Em qualquer redesign, esses componentes podem mudar de visual mas o conceito (CTA dourado, divisor gradient, badge premium) deve continuar reconhecível.**
+
+### 3.2 Componentes funcionais — workout (críticos)
+
+Localização: `src/components/workout/`
+
+| Componente | Função | Notas de design |
+|---|---|---|
+| `ExerciseCard.tsx` | Container colapsável de exercício, dispatcher de renderer | Borda muda para emerald quando todas as séries feitas + scroll auto pro próximo |
+| `set-renderers/normalSet.tsx` | Renderiza UMA série bilateral (peso/reps/RPE) | Header de colunas só na primeira série, badge slam ao concluir |
+| `set-renderers/normalSet.tsx` (modo unilateral) | Mesmo arquivo, modo L/R com badges azul/laranja | Cada lado tem seu próprio botão de "feito"; série só conta como done quando ambos feitos |
+| `set-renderers/dropSetSet.tsx`, `restPauseSet.tsx`, etc. | Variantes pra métodos especiais (drop-set, rest-pause, cluster, FST-7, sistema 21, onda, group methods) | 14 renderizadores. Precisam revisão de consistência visual entre eles |
+| `PlankSetInput.tsx` | Modal específico de Prancha (peso corporal + tempo + countdown integrado) | Recém-adicionado, padrão para futuros isométricos |
+| `RestTimerOverlay.tsx` | Fullscreen countdown overlay | Compartilhado entre rest entre séries E execução de Prancha (`context.kind`: `'rest' \| 'plank'`) |
+| `SetInputRow.tsx` | Renderer simples (não usado no fluxo principal — `ExerciseCard` despacha direto pros set-renderers) | **Atenção:** legacy. Pode ser removido em refactor |
+| `WorkoutFooter.tsx` | Botão "Finalizar" + cronômetro + pause | Footer fixo bottom, glow on completion |
+
+### 3.3 Componentes funcionais — dashboard
+
+| Componente | Função |
+|---|---|
+| `dashboard/DashboardHeader.tsx` | Logo + sync badge + menu, fixed top |
+| `dashboard/StudentDashboard.tsx` | Home view, lista de treinos do dia |
+| `dashboard/WorkoutCard.tsx` | Card de treino na lista, mostra exercícios e botão "Iniciar" |
+| `dashboard/WeeklyAIReport.tsx` | Insights de IA |
+| `dashboard/CalorieTimeline.tsx`, `MacroPieChart.tsx` | Tab de nutrição |
+
+### 3.4 Modais e overlays
+
+Carregados via `next/dynamic` para code-splitting:
+
+| Componente | Tipo | Quando aparece |
+|---|---|---|
+| `WorkoutWizardModal` | Fullscreen step | Ao criar treino com IA |
+| `ExpressWorkoutModal` | Fullscreen | Treino rápido |
+| `SettingsModal` | Sidesheet | Configurações |
+| `IncomingInviteModal` | Center modal, backdrop-blur-md | Convite de coach/grupo |
+| `GlobalDialog` | Confirm/alert | Via `DialogContext` (qualquer lugar) |
+| `PreCheckinModal` | Bottom-sheet | Antes de iniciar treino |
+| `RestTimerOverlay` | Fullscreen | Countdown |
+
+Padrão: backdrop com `backdrop-blur-md` + `bg-black/70`, conteúdo `rounded-2xl border border-yellow-500/20`, animação `overlay-enter` (fade + scale).
+
+### 3.5 Inputs
+
+```css
+/* base — inputs roomy (peso) */
+.bg-black/40 .border .border-neutral-700/80 .rounded-xl .px-2.5 .py-2 .text-sm .text-white
+.outline-none .focus:ring-1 .ring-yellow-500 .focus:border-yellow-500/50
+.placeholder:text-neutral-600 .placeholder:text-xs .focus:placeholder:opacity-0
+
+/* compact — inputs estreitos (reps, RPE) */
+mesma base + .px-1.5 .text-center
+```
+
+**Padrão importante:** `inputMode="decimal"` em peso/reps (teclado numérico em mobile sem necessidade de `type="number"` que causa spinners feios).
+
+### 3.6 Botões
+
+| Variante | Quando usar | Visual |
+|---|---|---|
+| Gold solid | CTA principal único na tela | `bg-yellow-500 text-black font-black` |
+| Gold gradient | Ações de celebração / iniciar | Gradient gold + pulse-glow on success |
+| Ghost (border) | Ação secundária | `border border-neutral-700 text-neutral-300 bg-transparent` |
+| Subtle | Toggle, action interna | `bg-neutral-900/50 border border-neutral-800` |
+| Danger | Destrutivo | `bg-red-500/90 text-white` ou `border-red-500/40 text-red-400 bg-transparent` |
+| Success | Confirmação após ação | `bg-emerald-500 text-black` |
+
+**Padrão de feedback:** `active:scale-95 transition-all duration-150` em todos os botões. Plus haptic feedback em mobile (`triggerHaptic()`).
+
+### 3.7 Cards (estados)
+
+```
+Default:       bg-neutral-900/50 border border-neutral-800/80 rounded-xl
+Hover:         translateY(-2px), shadow lift (utility .card-interactive)
+Done state:    bg-emerald-950/30 border-emerald-500/30 (transição 0.6s)
+Active state:  border-yellow-500/40 shadow-yellow glow
+```
+
+---
+
+## 4. Animações e microinterações
+
+Todas em `src/app/globals.css:5-366` (keyframes) + utilities. **Não são decoração — comunicam estado.** Em qualquer redesign, o vocabulário de animação deve ser preservado mesmo que as durações/curvas mudem.
+
+| Nome | Duração | Quando dispara | Significado |
+|---|---|---|---|
+| `badge-slam` | 0.5s | Ao marcar série como feita | Celebração de conquista |
+| `button-slam` | 0.3s | Press de botão de complete | Feedback tátil visual |
+| `pulse-glow` | 1.6s ∞ | Botão "Finalizar" quando todos exercícios feitos | "Você terminou — clique aqui" |
+| `shimmer` | 1.5s | Loading skeletons + sweep no logo | Atividade |
+| `gold-flow` | 3s | Botão "Iniciar Treino" gradiente | Convite |
+| `aurora-pulse` | ∞ | Story rings (se story disponível) | Atenção sutil |
+| `streak-shake` | 2.5s | Emoji 🔥 do streak | Conquista de hábito |
+| `prBadgeIn` | 0.5s | Quando PR detectado | Celebração grande |
+| `dropdownIn` | 0.18s | Menus | Snap responsivo |
+| `slideUp` | 0.3s | Bottom-sheets, toasts | Entrada padrão |
+| `overlay-enter` | 0.2s | Modais | Fade + scale |
+
+**Stagger pattern:** `.stagger-children > *` aplica delay incremental (0–300ms) em até 6 itens. Usado em listas que aparecem (ex: dashboard ao carregar).
+
+**Princípio:** animação só justifica seu peso se comunicar algo. Em mobile, durações curtas (≤300ms) pra parecer responsivo. Glow/pulse infinito apenas em estado de "atenção pendente" (CTA principal aguardando ação).
+
+---
+
+## 5. Iconografia
+
+**Pacote:** `lucide-react` (40+ usos). Tamanhos comuns: 12, 14, 16, 18, 20 (props diretos no JSX, não Tailwind).
+
+**Top icons usados:**
+- `Dumbbell` (logo, headers, exercise indicator)
+- `Check` / `CheckCircle2` (completion)
+- `X` (close)
+- `ArrowLeft` (back)
+- `Crown` (VIP)
+- `Loader2` (`animate-spin`)
+- `MessageSquare` (notas/observações)
+- `Play` / `Square` (timer iniciar/parar)
+- `ChevronDown` / `ChevronUp` (collapse)
+- `Edit` (editar)
+- `Camera` (avatar)
+
+**Custom SVG/PNG:** halter 3D em `/public/header-dumbbell.png` (a única imagem rasterizada de marca).
+
+**Princípio:** Lucide é a baseline. Substituir por SVG custom só quando a forma for marca (halter). Tamanhos sempre em múltiplos de 2 (12/14/16/18/20).
+
+---
+
+## 6. Telas e fluxos
+
+### 6.1 Roteamento via state, não router
+
+Todas as telas principais vivem em `src/app/(app)/dashboard/IronTracksAppClientImpl.tsx` num único componente client-side. O state `view: string` controla qual tela renderiza. **Não é Next.js routing tradicional.**
+
+```ts
+type View =
+  | 'dashboard'        // home, default
+  | 'active-workout'   // treino em andamento (fullscreen, sem bottom nav)
+  | 'history'          // treinos passados
+  | 'chat-list'        // conversas
+  | 'chat-direct'      // DM
+  | 'community'        // feeds sociais
+  | 'admin'            // painel coach (admin only)
+  | 'profile'          // perfil do usuário
+  | 'exercise-editor'  // criar/editar exercício
+  | 'workout-report'   // relatório pós-treino
+  | 'vip-hub'          // features premium
+```
+
+**Implicação para redesign:** transições entre telas podem ser animadas (não há reload). Bottom nav é condicional (esconde em fullscreen views).
+
+### 6.2 Fluxos críticos
+
+**Iniciar treino:**
+1. Dashboard mostra cards de treino do dia
+2. Usuário toca "Iniciar Treino" → confirm modal com tempo estimado
+3. Pre-checkin (se ativo): mood/energia/sono
+4. Entra em `active-workout` (fullscreen)
+5. Sequência de exercícios → cada exercício tem N séries
+6. Series tipo padrão: peso + reps + RPE → botão OK marca como feita
+7. Series unilaterais: dois lados (L/R), cada um com seu OK
+8. Series Prancha: peso corporal + tempo alvo + botão Iniciar (timer integrado)
+9. Ao terminar todas: botão Finalizar (pulsa)
+10. Post-checkin opcional → salva sessão → vai pra `workout-report`
+
+**Pós-treino:**
+1. `workout-report`: cards de métricas (volume, duração, PRs detectados, gráfico de músculos trabalhados, insights de IA)
+2. Botão "Compartilhar" → screenshot ou link para feed social
+
+**Admin/coach:**
+1. View `admin` (só pra usuários com role coach/admin)
+2. Lista de alunos, criação/edição de templates, aprovação, assinatura de planos
+3. Sistema separado de UI mas usa os mesmos primitivos PremiumUI
+
+### 6.3 Sistema de PRs e gamificação
+
+- **Iron Rank:** sistema de níveis baseado em volume total levantado (0kg → Lenda Imortal). Mostrado no header da home.
+- **PRs (Personal Records):** detectados automaticamente via Epley 1RM ou peso×reps direto. Animação `prBadgeIn` celebra quando aparece.
+- **Streak de treinos:** emoji 🔥 com animação `streak-shake` no header.
+- **Badges:** crown (VIP), volume tier, frequência semanal.
+
+**Princípio:** gamificação é central pro engajamento, mas nunca atrapalha o flow de treino. Badges aparecem em momentos de pausa (header, home, post-workout) — nunca no meio de uma série.
+
+---
+
+## 7. Padrões UX específicos do fitness
+
+### 7.1 Header de treino ativo
+```
+[← Voltar]  [+ adicionar ex]  [⋮ menu]   [progress ring] X/Y  [⏰ hh:mm:ss]
+```
+- Voltar: sai com confirm
+- Add exercise: insere extra
+- Menu: opções (skip, edit)
+- Progress: ring circular com % de séries feitas
+- Timer: cronômetro do treino (pode pausar)
+
+### 7.2 Exercise card colapsável
+- Borda **yellow** quando ativo (em progresso ou próximo)
+- Borda **emerald** quando todas as séries feitas
+- Header com número + nome + sets + tempo descanso + método
+- Bloco de instruções (collapsible)
+- Toolbar de ações (vídeo, IA, link, refresh, deload, edit)
+- Lista de séries (cada uma é um set-renderer)
+- "Série extra" pra adicionar manual
+- Lixeira pra remover (com confirm)
+
+### 7.3 Set input row (3-col grid)
+```
+[💬 notes] [Peso] [Reps] [RPE] [✓ OK]
+```
+Bilateral: única linha por série
+Unilateral: duas linhas por série (L em azul, R em laranja), badge `LADO L`/`LADO R`, OKs separados
+
+### 7.4 Rest timer overlay
+- Fullscreen com backdrop opaco
+- Timer central XX:XX (animado)
+- Contexto (próximo exercício/série)
+- Botões: Pular, +30s, Parar
+- Som + vibração ao terminar
+- Background task em iOS via Capacitor
+
+### 7.5 Toasts e notificações inline
+- `ActionToast` no top-center
+- Animação `toast-enter` (slide down + fade)
+- Auto-dismiss em 4s
+- Tipos: success (emerald), warning (yellow), error (red)
+- Sem push notifications via web (só Capacitor mobile)
+
+---
+
+## 8. Capacitor / mobile
+
+### 8.1 Plugins ativos
+- `@capacitor/core`, `@capacitor/filesystem` (save Blob)
+- Custom `irontracksNative.ts` registra: haptic feedback, push notifications, native timer actions, Apple Health sync
+- Live Activities iOS (timer no Dynamic Island/Lock Screen)
+
+### 8.2 Web vs mobile — diferenças intencionais
+- Mobile: scroll handle hidden, touch-action manipulation, haptic em buttons
+- Web desktop: scrollbar custom (gold), hover states explícitos
+
+### 8.3 Constraints
+- Nenhum push em web (apenas in-app `ActionToast`)
+- Câmera/upload usa `<input type="file">` em web, plugin nativo em mobile
+- Compartilhamento usa Web Share API com fallback
+
+---
+
+## 9. O que está bom (preservar)
+
+1. **DNA gold + dark + italic** — funciona, é reconhecível, não faltar.
+2. **Animações que comunicam estado** — slam ao concluir, glow no botão Finalizar, shimmer em loading. Bem calibradas.
+3. **Hierarquia tipográfica responsiva** — `clamp()` nos `text-title-*` escala bem entre mobile e desktop.
+4. **Safe areas no Capacitor** — bem aplicadas, sem falhas de UI cortada.
+5. **Sistema de cores semânticas** — emerald/yellow/red consistentes através do app.
+6. **Modal pattern** — backdrop-blur-md + border yellow/20 + rounded-2xl é coeso.
+
+## 10. Áreas com ressalva (vale repensar)
+
+1. **14 set-renderers diferentes** (`normalSet.tsx`, `dropSetSet.tsx`, `clusterSet.tsx`, `restPauseSet.tsx`, `fST7Set.tsx`, etc.) com inconsistências visuais menores entre eles. Vale unificar a base e diferenciar só por tokens (cor de header da série, ícones).
+2. **3 tipos `SetDetail` diferentes** (`src/types/app.ts`, `src/types/workout.ts`, `src/components/ExerciseEditor/types.ts`) — débito técnico que mistura camelCase/snake_case. Não é UI mas afeta como dados chegam à UI.
+3. **`SetInputRow.tsx` legacy** — não é o renderer real do treino ativo (ExerciseCard despacha pros set-renderers). Pode ser removido ou clarificado.
+4. **Bottom nav inconsistente** — algumas views têm, outras não. Falta um padrão claro de quando aparece.
+5. **`LoadingScreen` que mostra "não foi possível carregar" depois de 8s** — UX defensiva mas confusa em dev mode lento. Vale repensar safety valve.
+6. **Padrão de "edit exercise during workout"** — modal denso com muitos campos (`Modals.tsx` linhas 524-560 só pro toggle unilateral). Pode ser progressive disclosure.
+7. **Pre/post-checkin** — atualmente são modais separados; pode virar um wizard mais coeso.
+8. **Estatísticas e insights** — gráficos de musculatura, calorias, volume — bem feitos individualmente mas não conversam visualmente entre si. Falta um sistema de chart compartilhado.
+9. **VIP / Iron Rank / Badges** — gamificação funciona mas o visual de cada elemento é levemente diferente (gradients diferentes, tamanhos diferentes). Vale unificar.
+10. **Exercise editor (`ExerciseEditor/`)** — é a tela mais densa do app. Tem campos demais visíveis ao mesmo tempo. Candidato a refatoração com tabs ou steps.
+
+---
+
+## 11. Princípios para evolução
+
+Se o Claude Design vai trabalhar nesse app, esses princípios não são negociáveis:
+
+1. **Performance > polish.** App precisa abrir e responder em sub-segundos. Animações nunca podem bloquear interação. Transições entre telas devem ser visualmente ricas mas computacionalmente baratas.
+
+2. **Mobile-first absoluto.** Toda decisão de layout começa no breakpoint mobile (< 640px). Desktop é uma evolução, não a referência.
+
+3. **Touch-targets generosos.** Mínimo 44px de altura em qualquer elemento interativo (input, botão, toggle, link).
+
+4. **Dark only.** Manter. Reconsiderar luz só com proposta sólida que mantenha tom premium.
+
+5. **Gold é o herói.** Não diluir a cor da marca em "modo plano" ou "estilo neutro". O usuário associa gold = ação importante.
+
+6. **Tipografia black/italic é assinatura.** Wordmark IRONTRACKS, headers de PR, toasts de celebração — tudo italic black. Resto do app pode ser regular/medium.
+
+7. **Animação só comunica.** Nada de "delight" gratuito. Toda animação deve ter um significado funcional (estado mudou, atenção precisa ir aqui, sucesso aconteceu).
+
+8. **Densidade vs respirar.** Tela de treino ativo precisa de densidade (muitas séries visíveis). Dashboard pode respirar mais. Não generalizar.
+
+9. **Coach vs aluno são apps diferentes na mesma casa.** O painel admin tem necessidades distintas (tabelas, listas grandes, edição em batch) — não forçar o mesmo visual do app de aluno.
+
+10. **Capacitor é first-class.** Considerar safe areas, haptics, Live Activities iOS, plugins nativos em todas as decisões. Web é a "versão para desktop", não o contrário.
+
+---
+
+## 12. Mapa rápido para começar
+
+Se for só ler 5 arquivos pra entender o app:
+
+1. `src/app/globals.css` — todos os tokens, animações, utilities
+2. `src/components/ui/PremiumUI.tsx` — primitivos de marca
+3. `src/components/workout/set-renderers/normalSet.tsx` — UI mais usada do app (renderer de série)
+4. `src/components/workout/ExerciseCard.tsx` — dispatcher e card colapsável
+5. `src/app/(app)/dashboard/IronTracksAppClientImpl.tsx` — view router e state global
+
+Se for só rodar 1 fluxo:
+- Login → dashboard → iniciar treino de SEG → completar 2 séries de qualquer exercício → finalizar → ver report.
+
+---
+
+**Última atualização:** 2026-04-20 · Claude Code (auditoria automatizada do estado atual + síntese para input de redesign).

--- a/docs/superpowers/plans/2026-04-20-prancha-isometrica.md
+++ b/docs/superpowers/plans/2026-04-20-prancha-isometrica.md
@@ -1,0 +1,1127 @@
+# Prancha Isométrica — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transformar o modal de série do exercício Prancha em um modal específico com peso corporal auto-preenchido, tempo alvo (substituindo reps) e countdown integrado — reusando a infra de timer de descanso existente.
+
+**Architecture:** Helper `isPlank(name)` detecta o exercício; novo componente `PlankSetInput` renderiza UI alternativa (peso corporal + tempo + botão Iniciar/Parar); coluna `duration_seconds` adicionada em `sets` via migration aditiva nullable; timer existente (`startTimer` + `RestTimerOverlay`) ganha kind `'plank'` com copy condicional e callback `onComplete`.
+
+**Tech Stack:** Next.js 16 + React 19 + TypeScript strict, Vitest (unit), React Testing Library, Playwright (E2E), Supabase (PostgreSQL via MCP), Tailwind v4, Capacitor 8 (iOS/Android hybrid).
+
+**Spec:** [`docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md`](../specs/2026-04-20-prancha-isometrica-design.md)
+
+---
+
+## Task 1: Migration — adicionar coluna `duration_seconds` em `sets`
+
+**Files:**
+- Create: `supabase/migrations/<gerado_pelo_MCP>_add_duration_seconds_to_sets.sql`
+- Modify: `src/types/supabase.ts` (regenerado pelo MCP)
+
+- [ ] **Step 1: Verificar migrations atuais**
+
+Run: usar tool `mcp__supabase__list_migrations` para listar migrations existentes e confirmar que `duration_seconds` não existe. Anotar a última migration aplicada.
+
+- [ ] **Step 2: Aplicar a migration via MCP**
+
+Usar tool `mcp__supabase__apply_migration` com `name: "add_duration_seconds_to_sets"` e o seguinte SQL:
+
+```sql
+ALTER TABLE sets
+  ADD COLUMN duration_seconds INTEGER NULL
+  CHECK (duration_seconds IS NULL OR duration_seconds > 0);
+COMMENT ON COLUMN sets.duration_seconds
+  IS 'Duração em segundos para exercícios isométricos (ex: Prancha). NULL para exercícios baseados em reps.';
+```
+
+- [ ] **Step 3: Verificar que a migration entrou**
+
+Usar `mcp__supabase__list_migrations` novamente e confirmar que a migration aparece no topo.
+
+- [ ] **Step 4: Regenerar tipos TypeScript**
+
+Usar tool `mcp__supabase__generate_typescript_types` e escrever o conteúdo retornado em `src/types/supabase.ts` (substituindo o arquivo inteiro). Confirmar que a tabela `sets` agora tem `duration_seconds: number | null` no tipo `Row`.
+
+- [ ] **Step 5: Verificar TypeScript ainda compila**
+
+Run: `npx tsc --noEmit`
+Expected: zero erros (a coluna nova é opcional, código existente que lê/escreve `sets` não quebra).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/ src/types/supabase.ts
+git commit -m "feat(db): add duration_seconds column to sets for isometric exercises"
+```
+
+---
+
+## Task 2: Atualizar schemas Zod e tipos de app
+
+**Files:**
+- Modify: `src/schemas/database.ts:70-93`
+- Modify: `src/types/app.ts:26-40`
+- Modify: `src/types/workout.ts:5-14`
+- Test: `src/schemas/__tests__/database.set.test.ts` (criar)
+
+- [ ] **Step 1: Escrever teste que falha**
+
+Criar `src/schemas/__tests__/database.set.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { SetRowSchema } from '../database'
+
+describe('SetRowSchema — duration_seconds', () => {
+  const base = {
+    id: '00000000-0000-0000-0000-000000000001',
+    exercise_id: '00000000-0000-0000-0000-000000000002',
+    weight: 82,
+    reps: null,
+    rpe: null,
+    set_number: 1,
+    completed: true,
+    is_warmup: false,
+    advanced_config: null,
+  }
+
+  it('aceita duration_seconds como número positivo', () => {
+    const parsed = SetRowSchema.parse({ ...base, duration_seconds: 60 })
+    expect(parsed.duration_seconds).toBe(60)
+  })
+
+  it('aceita duration_seconds como null (exercícios de reps)', () => {
+    const parsed = SetRowSchema.parse({ ...base, duration_seconds: null })
+    expect(parsed.duration_seconds).toBeNull()
+  })
+
+  it('rejeita duration_seconds <= 0', () => {
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: 0 })).toThrow()
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: -5 })).toThrow()
+  })
+
+  it('rejeita duration_seconds decimal', () => {
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: 1.5 })).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Rodar teste, confirmar que falha**
+
+Run: `npx vitest run src/schemas/__tests__/database.set.test.ts`
+Expected: todos os 4 testes falham com erro tipo "Unrecognized key: duration_seconds" ou similar (o schema atual não tem esse campo).
+
+- [ ] **Step 3: Adicionar `duration_seconds` ao `SetRowSchema`**
+
+Em `src/schemas/database.ts`, substituir o bloco do `SetRowSchema` (linhas 70-93):
+
+```ts
+export const SetRowSchema = z.object({
+  id: z.string().uuid(),
+  exercise_id: z.string().uuid(),
+  weight: z.number().nullable(),
+  reps: z.string().nullable(),
+  rpe: z.number().nullable(),
+  set_number: z.number().int().default(1),
+  completed: z.boolean().default(false),
+  is_warmup: z.boolean().nullable(),
+  advanced_config: z.unknown().nullable(),
+  duration_seconds: z.number().int().positive().nullable(),
+})
+export const SetSchema = SetRowSchema.transform((row) => ({
+  id: row.id,
+  exerciseId: row.exercise_id,
+  weight: row.weight,
+  reps: row.reps,
+  rpe: row.rpe,
+  setNumber: row.set_number,
+  completed: row.completed,
+  isWarmup: row.is_warmup,
+  advancedConfig: row.advanced_config,
+  durationSeconds: row.duration_seconds,
+}))
+export type SetRow = z.infer<typeof SetRowSchema>
+export type Set = z.infer<typeof SetSchema>
+```
+
+- [ ] **Step 4: Rodar teste, confirmar que passa**
+
+Run: `npx vitest run src/schemas/__tests__/database.set.test.ts`
+Expected: 4 passed.
+
+- [ ] **Step 5: Adicionar `durationSeconds` ao `SetDetail` (types/app.ts)**
+
+Em `src/types/app.ts`, na interface `SetDetail` (linhas 26-40), adicionar uma linha após `completed?: boolean;`:
+
+```ts
+export interface SetDetail {
+  set_number: number;
+  reps: string | number | null;
+  rpe: number | null;
+  weight: number | null;
+  isWarmup: boolean;
+  advancedConfig: AdvancedConfig | AdvancedConfig[] | null;
+  completed?: boolean;
+  durationSeconds?: number | null;
+  it_auto?: {
+    source: string;
+    kind: string;
+    label: string;
+    hash: string;
+  } | null;
+}
+```
+
+- [ ] **Step 6: Adicionar `durationSeconds` ao `SetDetailSchema` (types/workout.ts)**
+
+Em `src/types/workout.ts`, substituir `SetDetailSchema` (linhas 5-13):
+
+```ts
+export const SetDetailSchema = z.object({
+    set_number: z.number().int().min(1),
+    reps: z.union([z.string(), z.number()]).nullable().optional(),
+    weight: z.number().nullable().optional(),
+    rpe: z.number().min(0).max(10).nullable().optional(),
+    is_warmup: z.boolean().optional(),
+    completed: z.boolean().optional(),
+    advanced_config: z.unknown().nullable().optional(),
+    duration_seconds: z.number().int().positive().nullable().optional(),
+})
+```
+
+Também adicionar `durationSeconds` ao tipo `WorkoutSet` (linhas 95-103):
+
+```ts
+export interface WorkoutSet {
+    setNumber: number
+    reps?: string | null
+    rpe?: number | null
+    weight?: number | null
+    isWarmup: boolean
+    advancedConfig?: unknown
+    completed?: boolean
+    durationSeconds?: number | null
+}
+```
+
+- [ ] **Step 7: Verificar typecheck passa**
+
+Run: `npx tsc --noEmit`
+Expected: zero erros.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/schemas/database.ts src/types/app.ts src/types/workout.ts src/schemas/__tests__/database.set.test.ts
+git commit -m "feat(schemas): add duration_seconds/durationSeconds to set types"
+```
+
+---
+
+## Task 3: Helper `isPlank` + testes
+
+**Files:**
+- Create: `src/utils/exerciseTracking.ts`
+- Test: `src/utils/__tests__/exerciseTracking.test.ts`
+
+- [ ] **Step 1: Escrever teste que falha**
+
+Criar `src/utils/__tests__/exerciseTracking.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { isPlank } from '../exerciseTracking'
+
+describe('isPlank', () => {
+  it.each([
+    'Prancha',
+    'prancha',
+    'Prancha lateral',
+    'Prancha com toques no ombro',
+    'Plank',
+    'plank',
+    'Side plank',
+    'PRANCHA',
+  ])('retorna true para %s', (name) => {
+    expect(isPlank(name)).toBe(true)
+  })
+
+  it.each([
+    'Supino',
+    'Agachamento',
+    'Rosca direta',
+    'Bird-dog',
+    'Dead bug',
+    'Abdominal',
+    'Abdominal infra',
+    '',
+  ])('retorna false para %s', (name) => {
+    expect(isPlank(name)).toBe(false)
+  })
+
+  it('retorna false para entradas nulas/undefined', () => {
+    expect(isPlank(null as unknown as string)).toBe(false)
+    expect(isPlank(undefined as unknown as string)).toBe(false)
+  })
+
+  it('ignora espaços em branco nas bordas', () => {
+    expect(isPlank('  Prancha  ')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Rodar teste, confirmar que falha**
+
+Run: `npx vitest run src/utils/__tests__/exerciseTracking.test.ts`
+Expected: falha com "Cannot find module '../exerciseTracking'".
+
+- [ ] **Step 3: Implementar `isPlank`**
+
+Criar `src/utils/exerciseTracking.ts`:
+
+```ts
+const PLANK_REGEX = /\b(prancha|plank)\b/i
+
+export function isPlank(exerciseName: string | null | undefined): boolean {
+  if (!exerciseName || typeof exerciseName !== 'string') return false
+  return PLANK_REGEX.test(exerciseName.trim())
+}
+```
+
+- [ ] **Step 4: Rodar teste, confirmar que passa**
+
+Run: `npx vitest run src/utils/__tests__/exerciseTracking.test.ts`
+Expected: todos passam.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/exerciseTracking.ts src/utils/__tests__/exerciseTracking.test.ts
+git commit -m "feat(utils): add isPlank helper for isometric exercise detection"
+```
+
+---
+
+## Task 4: Helper `formatSetSummary` + testes
+
+**Files:**
+- Create: `src/utils/formatSetSummary.ts`
+- Test: `src/utils/__tests__/formatSetSummary.test.ts`
+
+- [ ] **Step 1: Escrever teste que falha**
+
+Criar `src/utils/__tests__/formatSetSummary.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { formatSetSummary } from '../formatSetSummary'
+
+describe('formatSetSummary', () => {
+  it('Prancha com duration_seconds novo formato: "60s × 82 kg"', () => {
+    const out = formatSetSummary(
+      { weight: 82, reps: null, duration_seconds: 60 },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s × 82 kg')
+  })
+
+  it('Prancha legado (reps="60", duration_seconds=null): fallback para reps como segundos', () => {
+    const out = formatSetSummary(
+      { weight: 82, reps: '60', duration_seconds: null },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s × 82 kg')
+  })
+
+  it('Prancha sem peso: apenas "60s"', () => {
+    const out = formatSetSummary(
+      { weight: null, reps: null, duration_seconds: 60 },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s')
+  })
+
+  it('Supino (não-prancha): "10 × 80 kg"', () => {
+    const out = formatSetSummary(
+      { weight: 80, reps: '10', duration_seconds: null },
+      { name: 'Supino reto' },
+    )
+    expect(out).toBe('10 × 80 kg')
+  })
+
+  it('Supino sem peso: "10"', () => {
+    const out = formatSetSummary(
+      { weight: null, reps: '10', duration_seconds: null },
+      { name: 'Supino reto' },
+    )
+    expect(out).toBe('10')
+  })
+
+  it('Set vazio retorna string vazia', () => {
+    expect(formatSetSummary({ weight: null, reps: null, duration_seconds: null }, { name: 'Supino reto' })).toBe('')
+  })
+})
+```
+
+- [ ] **Step 2: Rodar teste, confirmar que falha**
+
+Run: `npx vitest run src/utils/__tests__/formatSetSummary.test.ts`
+Expected: falha com "Cannot find module '../formatSetSummary'".
+
+- [ ] **Step 3: Implementar `formatSetSummary`**
+
+Criar `src/utils/formatSetSummary.ts`:
+
+```ts
+import { isPlank } from './exerciseTracking'
+
+type SetLike = {
+  weight?: number | null
+  reps?: string | number | null
+  duration_seconds?: number | null
+  durationSeconds?: number | null
+}
+
+type ExerciseLike = {
+  name?: string | null
+}
+
+export function formatSetSummary(set: SetLike, exercise: ExerciseLike): string {
+  const name = exercise?.name ?? ''
+  const weight = typeof set.weight === 'number' && set.weight > 0 ? set.weight : null
+  const weightStr = weight !== null ? ` × ${weight} kg` : ''
+
+  if (isPlank(name)) {
+    const duration =
+      (typeof set.duration_seconds === 'number' && set.duration_seconds > 0 ? set.duration_seconds : null) ??
+      (typeof set.durationSeconds === 'number' && set.durationSeconds > 0 ? set.durationSeconds : null) ??
+      (typeof set.reps === 'string' && /^\d+$/.test(set.reps.trim()) ? Number(set.reps) : null) ??
+      (typeof set.reps === 'number' && set.reps > 0 ? set.reps : null)
+    if (duration === null) return ''
+    return `${duration}s${weightStr}`
+  }
+
+  const repsNum =
+    (typeof set.reps === 'number' && set.reps > 0 ? set.reps : null) ??
+    (typeof set.reps === 'string' && set.reps.trim() !== '' ? set.reps.trim() : null)
+  if (repsNum === null) return ''
+  return `${repsNum}${weightStr}`
+}
+```
+
+- [ ] **Step 4: Rodar teste, confirmar que passa**
+
+Run: `npx vitest run src/utils/__tests__/formatSetSummary.test.ts`
+Expected: todos passam.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/formatSetSummary.ts src/utils/__tests__/formatSetSummary.test.ts
+git commit -m "feat(utils): add formatSetSummary helper for set rendering"
+```
+
+---
+
+## Task 5: Mapear e substituir formatadores "X reps × Y kg" existentes
+
+**Files:**
+- Discovered via grep (ver Step 1)
+
+- [ ] **Step 1: Mapear ocorrências de formatação manual de set**
+
+Usar Grep tool:
+
+```
+pattern: (\s×\s|\sreps\s?[×x])
+output_mode: content
+-n: true
+```
+
+Também:
+
+```
+pattern: \$\{.*reps.*\}.*×.*\$\{.*weight
+output_mode: content
+-n: true
+```
+
+Listar TODOS os arquivos que aparecem. Exemplos esperados (a confirmar): `src/components/workout/SetRenderers.tsx`, `src/utils/report/buildHtml.ts`, componentes de histórico.
+
+Para cada arquivo encontrado:
+  - Identificar a função/expressão que monta a string
+  - Verificar se está formatando set individual (candidato a usar `formatSetSummary`) ou outro uso incidental (deixar)
+
+- [ ] **Step 2: Para cada ocorrência identificada em Step 1, substituir pelo helper**
+
+Padrão geral:
+
+Antes:
+```ts
+const summary = `${set.reps} × ${set.weight} kg`
+```
+
+Depois:
+```ts
+import { formatSetSummary } from '@/utils/formatSetSummary'
+const summary = formatSetSummary(set, exercise)
+```
+
+Onde `exercise` precisa ter pelo menos `{ name }`. Se o código não tiver o exercício em escopo, passar `{ name: '' }` (o helper trata vazio — volta para o caminho não-prancha).
+
+- [ ] **Step 3: Verificar typecheck e lint passam**
+
+Run: `npx tsc --noEmit`
+Expected: zero erros.
+
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs <arquivos_editados> --max-warnings 0`
+Expected: output vazio.
+
+- [ ] **Step 4: Rodar todos os testes unit**
+
+Run: `npm run test:unit`
+Expected: todos passam (os formatadores antigos eram testados implicitamente; o novo helper cobre o comportamento).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "refactor: replace ad-hoc set summary strings with formatSetSummary"
+```
+
+---
+
+## Task 6: Estender `ActiveWorkoutContext.startTimer` com kind `'plank'` + `onComplete`
+
+**Files:**
+- Modify: `src/components/workout/ActiveWorkoutContext.tsx`
+- Modify: `src/components/workout/RestTimerOverlay.tsx` (copy condicional)
+
+- [ ] **Step 1: Ler `ActiveWorkoutContext.tsx` para entender a assinatura atual de `startTimer`**
+
+Run: ler `src/components/workout/ActiveWorkoutContext.tsx` (arquivo inteiro) e anotar:
+- Onde `startTimer` é definido
+- O tipo do segundo argumento (`context`)
+- Como `context.kind` é hoje tratado
+
+- [ ] **Step 2: Estender o tipo do `context`**
+
+Procurar o tipo que descreve o segundo argumento do `startTimer` (provavelmente uma interface inline ou exportada como `RestTimerContext` ou similar). Adicionar:
+
+```ts
+kind?: 'rest' | 'plank'
+onComplete?: (finalDurationSeconds?: number) => void
+```
+
+Se o tipo hoje é `kind?: string`, pode manter mais permissivo; apenas garantir que o código que checa `kind` reconheça `'plank'`.
+
+- [ ] **Step 3: Ajustar copy do `RestTimerOverlay` para prancha**
+
+Em `src/components/workout/RestTimerOverlay.tsx`, procurar o bloco que renderiza o título do overlay (provavelmente próximo a texto "Descanso" ou usando `context?.exerciseName`).
+
+Adicionar constante no topo do componente, logo após o destructure de props:
+
+```ts
+const isPlankMode = context?.kind === 'plank'
+const overlayTitle = isPlankMode ? 'Prancha' : 'Descanso'
+const finishedLabel = isPlankMode ? 'Tempo concluído!' : 'Descanso concluído!'
+```
+
+Substituir o título atual pelo uso de `overlayTitle` e a mensagem de fim pelo `finishedLabel`. Manter qualquer exibição de `context?.exerciseName` como está (ela complementa o título).
+
+- [ ] **Step 4: Chamar `context.onComplete` quando o timer zera**
+
+Procurar no `RestTimerOverlay.tsx` o ponto onde `onFinish` é chamado (quando `timeLeft <= 0`). Adicionar, logo antes ou depois de `onFinish`:
+
+```ts
+if (typeof context?.onComplete === 'function') {
+  context.onComplete()
+}
+```
+
+Se `onFinish` já invoca algo no context, deixar ambos — `onComplete` é um hook adicional para o consumidor que iniciou o timer.
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `npx tsc --noEmit`
+Expected: zero erros.
+
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs src/components/workout/ActiveWorkoutContext.tsx src/components/workout/RestTimerOverlay.tsx --max-warnings 0`
+Expected: output vazio.
+
+- [ ] **Step 6: Verificar que o timer de descanso continua funcionando**
+
+Run: `npm run test:unit`
+Expected: testes existentes que tocam timer/rest continuam verdes. Se houver teste específico do RestTimerOverlay, ele passa sem ajuste (copy default é "Descanso").
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/workout/ActiveWorkoutContext.tsx src/components/workout/RestTimerOverlay.tsx
+git commit -m "feat(timer): support plank kind with onComplete callback"
+```
+
+---
+
+## Task 7: Componente `PlankSetInput` + testes
+
+**Files:**
+- Create: `src/components/workout/PlankSetInput.tsx`
+- Test: `src/components/workout/__tests__/PlankSetInput.test.tsx`
+- Modify: `src/hooks/useSettings.ts` ou equivalente (se necessário ler `bodyWeightKg`; ver Step 1)
+
+- [ ] **Step 1: Descobrir como ler `bodyWeightKg` no contexto de workout ativo**
+
+Grep:
+```
+pattern: bodyWeightKg
+glob: src/**/*.ts*
+output_mode: content
+-n: true
+```
+
+Anotar qual hook ou context expõe `bodyWeightKg` (provavelmente `useSettings()` ou similar). Anotar o caminho de link para a tela de perfil (provavelmente `/profile` ou `/perfil` — confirmar via `Glob` em `src/app/**/profile*` e `**/perfil*`).
+
+- [ ] **Step 2: Escrever teste que falha**
+
+Criar `src/components/workout/__tests__/PlankSetInput.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PlankSetInput } from '../PlankSetInput'
+
+// Mock do ActiveWorkoutContext
+const mockStartTimer = vi.fn()
+const mockUpdateLog = vi.fn()
+
+vi.mock('../ActiveWorkoutContext', () => ({
+  useActiveWorkout: () => ({
+    getLog: () => ({}),
+    updateLog: mockUpdateLog,
+    startTimer: mockStartTimer,
+    getPlannedSet: () => ({ durationSeconds: 60 }),
+  }),
+}))
+
+// Mock do hook de settings — ajustar path conforme descoberto no Step 1
+vi.mock('@/hooks/useSettings', () => ({
+  useSettings: () => ({ bodyWeightKg: 82 }),
+}))
+
+const baseProps = {
+  ex: { name: 'Prancha' },
+  exIdx: 0,
+  setIdx: 0,
+}
+
+describe('PlankSetInput', () => {
+  beforeEach(() => {
+    mockStartTimer.mockReset()
+    mockUpdateLog.mockReset()
+  })
+
+  it('pré-preenche peso com bodyWeightKg do perfil', () => {
+    render(<PlankSetInput {...baseProps} />)
+    const weightInput = screen.getByLabelText(/peso corporal/i) as HTMLInputElement
+    expect(weightInput.value).toBe('82')
+  })
+
+  it('pré-preenche tempo alvo com valor da ficha', () => {
+    render(<PlankSetInput {...baseProps} />)
+    const timeInput = screen.getByLabelText(/tempo alvo/i) as HTMLInputElement
+    expect(timeInput.value).toBe('60')
+  })
+
+  it('clicar Iniciar chama startTimer com kind plank e onComplete', () => {
+    render(<PlankSetInput {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /iniciar/i }))
+    expect(mockStartTimer).toHaveBeenCalledTimes(1)
+    const [seconds, ctx] = mockStartTimer.mock.calls[0]
+    expect(seconds).toBe(60)
+    expect(ctx.kind).toBe('plank')
+    expect(typeof ctx.onComplete).toBe('function')
+  })
+})
+
+describe('PlankSetInput — sem peso cadastrado', () => {
+  beforeEach(() => {
+    vi.doMock('@/hooks/useSettings', () => ({
+      useSettings: () => ({ bodyWeightKg: null }),
+    }))
+  })
+
+  it('mostra mensagem pedindo para cadastrar peso no perfil', async () => {
+    vi.resetModules()
+    const { PlankSetInput: Fresh } = await import('../PlankSetInput')
+    render(<Fresh {...baseProps} />)
+    expect(screen.getByText(/cadastre seu peso no perfil/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 3: Rodar teste, confirmar que falha**
+
+Run: `npx vitest run src/components/workout/__tests__/PlankSetInput.test.tsx`
+Expected: falha com "Cannot find module '../PlankSetInput'".
+
+- [ ] **Step 4: Implementar `PlankSetInput`**
+
+Criar `src/components/workout/PlankSetInput.tsx`:
+
+```tsx
+import React, { useState, useRef, useCallback } from 'react'
+import Link from 'next/link'
+import { Play, Square } from 'lucide-react'
+import { useActiveWorkout } from './ActiveWorkoutContext'
+import { useSettings } from '@/hooks/useSettings' // ajustar se o path descoberto for diferente
+import { UnknownRecord } from './types'
+
+type Props = {
+  ex: UnknownRecord
+  exIdx: number
+  setIdx: number
+}
+
+export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
+  const { getLog, updateLog, startTimer, getPlannedSet } = useActiveWorkout()
+  const { bodyWeightKg } = useSettings()
+
+  const key = `${exIdx}-${setIdx}`
+  const log = getLog(key)
+  const plannedSet = getPlannedSet(ex, setIdx) as { durationSeconds?: number | null } | null
+
+  const initialWeight =
+    typeof log.weight === 'number' || typeof log.weight === 'string'
+      ? String(log.weight)
+      : bodyWeightKg != null
+        ? String(bodyWeightKg)
+        : ''
+  const initialDuration =
+    log.durationSeconds != null
+      ? String(log.durationSeconds)
+      : plannedSet?.durationSeconds != null
+        ? String(plannedSet.durationSeconds)
+        : ''
+
+  const [weight, setWeight] = useState(initialWeight)
+  const [targetSeconds, setTargetSeconds] = useState(initialDuration)
+  const [isRunning, setIsRunning] = useState(false)
+  const startedAtRef = useRef<number>(0)
+
+  const inputBase =
+    'w-full bg-black/40 border border-neutral-700/80 rounded-xl px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500 focus:border-yellow-500/50'
+
+  const handleStart = useCallback(() => {
+    const sec = Number(targetSeconds)
+    if (!Number.isFinite(sec) || sec <= 0) return
+    startedAtRef.current = Date.now()
+    setIsRunning(true)
+
+    startTimer(sec, {
+      kind: 'plank',
+      key,
+      exerciseName: String(ex?.name || '').trim(),
+      onComplete: () => {
+        // Timer zerou: salva a série com duration_seconds = meta (tempo alvo)
+        updateLog(key, {
+          weight: weight === '' ? null : Number(weight),
+          reps: null,
+          durationSeconds: sec,
+          done: true,
+        })
+        setIsRunning(false)
+      },
+    })
+  }, [targetSeconds, startTimer, key, ex?.name, updateLog, weight])
+
+  const handleStop = useCallback(() => {
+    // Usuário parou antes do fim: salva com duration_seconds = tempo decorrido real
+    const elapsedMs = Date.now() - startedAtRef.current
+    const aguentou = Math.max(1, Math.round(elapsedMs / 1000))
+    updateLog(key, {
+      weight: weight === '' ? null : Number(weight),
+      reps: null,
+      durationSeconds: aguentou,
+      done: true,
+    })
+    setIsRunning(false)
+    // cancelar o timer ativo — depende de API existente do context; se houver `cancelTimer()` usar aqui
+  }, [key, updateLog, weight])
+
+  const secondsNum = Number(targetSeconds)
+  const canStart = Number.isFinite(secondsNum) && secondsNum > 0
+
+  if (isRunning) {
+    // Estado simplificado enquanto timer rola — o visual principal fica por conta do RestTimerOverlay
+    return (
+      <div className="rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-neutral-300">Série {setIdx + 1} • Prancha em andamento</span>
+          <button
+            type="button"
+            onClick={handleStop}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-red-500/90 text-white text-xs font-black"
+          >
+            <Square size={14} />
+            Parar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80 space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center font-black text-[11px] bg-yellow-500 text-black">
+          {setIdx + 1}
+        </div>
+        <div className="flex-1 grid grid-cols-2 gap-1.5 min-w-0">
+          <div>
+            <label className="text-[10px] uppercase tracking-widest text-neutral-500 font-bold block mb-0.5">
+              Peso corporal (kg)
+            </label>
+            <input
+              aria-label="Peso corporal em kg"
+              inputMode="decimal"
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+              className={inputBase}
+              placeholder="kg"
+            />
+          </div>
+          <div>
+            <label className="text-[10px] uppercase tracking-widest text-neutral-500 font-bold block mb-0.5">
+              Tempo alvo (s)
+            </label>
+            <input
+              aria-label="Tempo alvo em segundos"
+              inputMode="numeric"
+              value={targetSeconds}
+              onChange={(e) => setTargetSeconds(e.target.value)}
+              className={inputBase}
+              placeholder="seg"
+            />
+          </div>
+        </div>
+      </div>
+
+      {bodyWeightKg == null && (
+        <p className="text-[11px] text-amber-400/80 px-1">
+          Cadastre seu peso no{' '}
+          <Link href="/perfil" className="underline hover:text-amber-300">
+            perfil
+          </Link>{' '}
+          para auto-preenchimento.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleStart}
+        disabled={!canStart}
+        className="w-full inline-flex items-center justify-center gap-2 py-2.5 rounded-xl font-black text-sm bg-yellow-500 text-black disabled:bg-neutral-800 disabled:text-neutral-600 transition-all duration-200"
+      >
+        <Play size={16} />
+        Iniciar {canStart ? `(${secondsNum}s)` : ''}
+      </button>
+    </div>
+  )
+}
+```
+
+**Observação para o executor:** se `useSettings` não existir com esse nome, descobrir o hook real no Step 1 e ajustar o import. Se o link do perfil não for `/perfil`, usar o caminho real descoberto.
+
+- [ ] **Step 5: Rodar teste, confirmar que passa**
+
+Run: `npx vitest run src/components/workout/__tests__/PlankSetInput.test.tsx`
+Expected: todos passam.
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `npx tsc --noEmit`
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs src/components/workout/PlankSetInput.tsx --max-warnings 0`
+Expected: ambos limpos.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/workout/PlankSetInput.tsx src/components/workout/__tests__/PlankSetInput.test.tsx
+git commit -m "feat(workout): add PlankSetInput component with integrated countdown"
+```
+
+---
+
+## Task 8: Integrar `PlankSetInput` em `SetInputRow`
+
+**Files:**
+- Modify: `src/components/workout/SetInputRow.tsx`
+
+- [ ] **Step 1: Modificar o componente para delegar em prancha**
+
+Em `src/components/workout/SetInputRow.tsx`, logo após os imports existentes, adicionar:
+
+```ts
+import { isPlank } from '@/utils/exerciseTracking'
+import { PlankSetInput } from './PlankSetInput'
+```
+
+E logo depois da linha `export const SetInputRow: React.FC<Props> = ({ ex, exIdx, setIdx }) => {` e do destructure do `useActiveWorkout`, adicionar antes de qualquer outra lógica:
+
+```ts
+const exerciseName = String(ex?.name ?? '')
+if (isPlank(exerciseName)) {
+  return <PlankSetInput ex={ex} exIdx={exIdx} setIdx={setIdx} />
+}
+```
+
+- [ ] **Step 2: Verificar typecheck + lint**
+
+Run: `npx tsc --noEmit`
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs src/components/workout/SetInputRow.tsx --max-warnings 0`
+Expected: ambos limpos.
+
+- [ ] **Step 3: Verificar que exercícios não-prancha continuam iguais**
+
+Run: `npm run test:unit`
+Expected: todos os testes existentes continuam verdes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/workout/SetInputRow.tsx
+git commit -m "feat(workout): delegate to PlankSetInput when exercise is plank"
+```
+
+---
+
+## Task 9: Atualizar `SetDetailsSection` (editor de ficha) para prancha
+
+**Files:**
+- Modify: `src/components/ExerciseEditor/SetDetailsSection.tsx`
+
+- [ ] **Step 1: Ler `SetDetailsSection.tsx` e identificar o bloco dos inputs**
+
+Ler o arquivo inteiro (251 linhas). Localizar o bloco que renderiza os labels "Carga (kg)" / "Reps" / "RPE" (referido no spec como linhas 79-115).
+
+- [ ] **Step 2: Importar `isPlank` e tornar o bloco condicional**
+
+No topo do arquivo, adicionar:
+
+```ts
+import { isPlank } from '@/utils/exerciseTracking'
+```
+
+Antes do JSX que renderiza os três inputs, adicionar:
+
+```ts
+const exerciseName = String((exercise as { name?: string })?.name ?? '')
+const isIsoPlank = isPlank(exerciseName)
+```
+
+(O nome da prop que carrega o exercício no componente é `exercise` ou equivalente — confirmar ao ler.)
+
+No bloco do input "Reps", trocar:
+
+```tsx
+<label>Reps</label>
+<input ... value={setDetail.reps ?? ''} onChange={...} />
+```
+
+Por:
+
+```tsx
+<label>{isIsoPlank ? 'Tempo alvo (s)' : 'Reps'}</label>
+<input
+  inputMode={isIsoPlank ? 'numeric' : 'decimal'}
+  aria-label={isIsoPlank ? 'Tempo alvo em segundos' : 'Repetições'}
+  value={isIsoPlank ? String(setDetail.durationSeconds ?? '') : String(setDetail.reps ?? '')}
+  onChange={(e) => {
+    const v = e.target.value
+    if (isIsoPlank) {
+      onChange({ ...setDetail, durationSeconds: v === '' ? null : Number(v), reps: null })
+    } else {
+      onChange({ ...setDetail, reps: v })
+    }
+  }}
+/>
+```
+
+(Ajustar nomes de callbacks/handlers para os reais no arquivo. Os principais pontos: quando `isIsoPlank`, grava `durationSeconds` e zera `reps`; caso contrário, grava `reps` normal.)
+
+No bloco do label "Carga (kg)", trocar apenas o texto do label quando `isIsoPlank`:
+
+```tsx
+<label>{isIsoPlank ? 'Peso corporal (kg)' : 'Carga (kg)'}</label>
+```
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `npx tsc --noEmit`
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs src/components/ExerciseEditor/SetDetailsSection.tsx --max-warnings 0`
+Expected: ambos limpos.
+
+- [ ] **Step 4: Verificar testes unit**
+
+Run: `npm run test:unit`
+Expected: todos verdes. Se houver teste específico para `SetDetailsSection`, verificar que o caminho não-prancha continua funcionando.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ExerciseEditor/SetDetailsSection.tsx
+git commit -m "feat(editor): replace reps with duration for plank in set template"
+```
+
+---
+
+## Task 10: Teste E2E (Playwright)
+
+**Files:**
+- Create: `e2e/plank-set.spec.ts`
+
+- [ ] **Step 1: Ler um E2E existente como referência**
+
+Glob: `e2e/*.spec.ts`. Abrir um arquivo curto (ex: `e2e/smoke.spec.ts` se existir) para ver como autenticação é mockada, como o usuário entra numa ficha, etc.
+
+- [ ] **Step 2: Escrever o spec**
+
+Criar `e2e/plank-set.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Prancha isométrica', () => {
+  test('usuário registra série de prancha via timer countdown', async ({ page }) => {
+    // Fazer login/seed como os outros E2E fazem (ajustar conforme padrão do projeto)
+    await page.goto('/')
+    // ... autenticação conforme padrão existente
+
+    // Assumindo que existe uma ficha com Prancha 3x60s ou que o usuário cria uma
+    await page.goto('/treino/novo')
+    await page.fill('[aria-label="Nome do treino"]', 'Teste Prancha')
+    // Adicionar exercício Prancha
+    await page.click('button:has-text("Adicionar exercício")')
+    await page.fill('[aria-label="Buscar exercício"]', 'Prancha')
+    await page.click('text=Prancha')
+
+    // Iniciar treino
+    await page.click('button:has-text("Iniciar treino")')
+
+    // Verificar que o modal da série mostra "Peso corporal" e "Tempo alvo"
+    await expect(page.getByLabel('Peso corporal em kg')).toBeVisible()
+    await expect(page.getByLabel('Tempo alvo em segundos')).toBeVisible()
+
+    // Ajustar tempo alvo para 5s (para o teste ser rápido)
+    await page.fill('[aria-label="Tempo alvo em segundos"]', '5')
+
+    // Iniciar
+    await page.click('button:has-text("Iniciar")')
+
+    // Aguardar o overlay do countdown aparecer
+    await expect(page.locator('text=Prancha em andamento')).toBeVisible()
+
+    // Aguardar o timer terminar (5s + pequena margem)
+    await page.waitForTimeout(6000)
+
+    // Verificar que a série foi marcada como concluída
+    await expect(page.locator('text=/5s\\s*×/')).toBeVisible()
+  })
+})
+```
+
+**Nota para o executor:** ajustar seletores, rotas e fluxo de autenticação conforme o padrão dos outros E2E do projeto. O ponto crítico é: abrir ficha de Prancha, rodar um countdown curto (5s), verificar que resultou em série concluída com `5s × ...`.
+
+- [ ] **Step 3: Rodar o E2E**
+
+Run: `npm run e2e -- e2e/plank-set.spec.ts`
+Expected: o teste passa. Se ele falhar por problemas de seletor/fluxo específicos do app, o executor ajusta iterativamente (máximo 3 tentativas — se não rodar, marcar o teste como `.fixme` e documentar no commit).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/plank-set.spec.ts
+git commit -m "test(e2e): register plank set via integrated countdown"
+```
+
+---
+
+## Task 11: Quality gates finais e preparação para deploy
+
+**Files:** (nenhum novo; só verificação)
+
+- [ ] **Step 1: TypeScript**
+
+Run: `npx tsc --noEmit`
+Expected: zero erros.
+
+- [ ] **Step 2: ESLint (projeto inteiro)**
+
+Run: `node --import tsx ./node_modules/eslint/bin/eslint.js --config eslint.config.mjs --max-warnings 0`
+Expected: output vazio.
+
+- [ ] **Step 3: Testes unit completos**
+
+Run: `npm run test:unit`
+Expected: todos passam.
+
+- [ ] **Step 4: Smoke tests**
+
+Run: `npm run test:smoke`
+Expected: todos os 13 smoke tests passam.
+
+- [ ] **Step 5: Scan de secrets (padrão do projeto)**
+
+Run: `npm run scan:secrets`
+Expected: nenhum secret leakado (não tocamos em env, mas é padrão).
+
+- [ ] **Step 6: Build local**
+
+Run: `npm run build`
+Expected: build completa sem erros e sem warnings.
+
+- [ ] **Step 7: (opcional) Capacitor sync**
+
+Run: `npm run cap:sync`
+Expected: sync ok. Só rodar se houver plano de testar em device nativo — nenhuma mudança nativa neste plano.
+
+- [ ] **Step 8: Criar PR para main**
+
+```bash
+git push -u origin <branch-atual>
+gh pr create --title "feat: Prancha como exercício isométrico com timer integrado" --body "$(cat <<'EOF'
+## Summary
+- Modal de série da Prancha agora exibe campo "Tempo alvo (s)" em vez de reps
+- Peso corporal auto-preenche via `settings.bodyWeightKg` do perfil
+- Timer countdown integrado (reusa infra do RestTimerOverlay) com som/vibração/notificação nativa e suporte a background
+- Nova coluna `duration_seconds` em `sets` (migration aditiva nullable — sem breaking change)
+
+## Test plan
+- [ ] TypeScript sem erros (`npx tsc --noEmit`)
+- [ ] ESLint sem warnings
+- [ ] Testes unitários todos verdes
+- [ ] Smoke tests verdes
+- [ ] E2E plank-set passa
+- [ ] Manual: exercício não-prancha (Supino) continua igual
+
+Ref: `docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR criada com sucesso. Não merjar direto — aguardar revisão humana.
+
+---
+
+## Rollback plan (para referência)
+
+Se algo der errado em produção:
+
+```sql
+ALTER TABLE sets DROP COLUMN duration_seconds;
+```
+
+E reverter o PR. Sets criados com `duration_seconds` perdem o tempo, mas nenhum outro registro é afetado. Sets antigos de Prancha (com tempo em `reps`) continuam íntegros independentemente deste rollback.

--- a/docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md
+++ b/docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md
@@ -1,0 +1,240 @@
+# Design: Prancha como exercício isométrico com timer integrado
+
+**Data:** 2026-04-20
+**Autor:** Maicon + Claude (brainstorming)
+**Escopo:** Somente o exercício Prancha (e variações detectáveis por nome). Outros isométricos ficam fora.
+
+---
+
+## 1. Problema
+
+Hoje, o exercício Prancha usa o mesmo esquema de qualquer outro exercício: os campos são `peso` e `reps`. Isso gera três problemas:
+
+1. **Peso**: o usuário tem que digitar o peso corporal a cada série — devia ser auto-preenchido do perfil.
+2. **Reps e tempo misturados**: hoje o usuário digita "60" na caixa de reps e entende como 60 segundos — mas o campo é textual e inconsistente.
+3. **Timer externo**: não existe contagem de tempo no app; o usuário usa cronômetro do celular à parte.
+
+## 2. Escopo e não-escopo
+
+**Dentro do escopo:**
+- Prancha, Prancha lateral, Prancha com toques no ombro (e qualquer outro exercício cujo nome contenha "prancha" ou "plank").
+- Campo peso auto-preenchido com `settings.bodyWeightKg`.
+- Campo de tempo alvo (segundos) substitui o campo de reps.
+- Timer countdown integrado no modal, reutilizando a infra de timer de descanso.
+- Tempo alvo configurável tanto na ficha quanto no modal de série (híbrido).
+
+**Fora do escopo:**
+- Outros exercícios isométricos (Bird-dog, Dead bug, Wall sit, Dead hang).
+- Taxonomia genérica de "tipo de tracking" (tempo, reps, distância, etc.).
+- Migração de sets antigos de Prancha que usaram `reps` como segundos — ficam como estão e são lidos via fallback.
+
+## 3. Decisões-chave
+
+| Decisão | Escolha |
+|---|---|
+| Escopo | Só Prancha (hardcoded via helper `isPlank`) |
+| Modo do timer | Countdown com meta (usuário define o tempo alvo) |
+| Peso corporal | Auto-preenche com `settings.bodyWeightKg`, editável |
+| Tempo alvo | Configurável na ficha + sobrescrever no modal (híbrido) |
+| Storage | Coluna nova `duration_seconds` em `sets` |
+| Timer | Reutiliza `WorkoutTimerContext` + `RestTimerOverlay` com novo modo `'plank'` |
+| Botão Cancelar | Não existe — se começou, conta (honesto) |
+| Peso sem cadastro | Mensagem inline com link para perfil; permite iniciar sem peso |
+
+## 4. Arquitetura
+
+Helper único `isPlank(exerciseName: string): boolean` em `src/utils/exerciseTracking.ts` centraliza a detecção (regex `/\bprancha\b|\bplank\b/i`). Todos os pontos que hoje mostram reps/peso consultam esse helper e renderizam condicionalmente.
+
+**Arquivos novos:**
+- `src/utils/exerciseTracking.ts` — helper `isPlank`
+- `src/components/workout/PlankSetInput.tsx` — substitui `SetInputRow` quando é prancha
+- `src/utils/formatSetSummary.ts` — centraliza formatação de série no histórico
+- `supabase/migrations/<TIMESTAMP>_add_duration_seconds_to_sets.sql` (timestamp gerado no momento da criação da migration via Supabase MCP)
+- `src/utils/__tests__/exerciseTracking.test.ts`
+- `src/utils/__tests__/formatSetSummary.test.ts`
+- `src/components/workout/__tests__/PlankSetInput.test.tsx`
+- `e2e/plank-set.spec.ts`
+
+**Arquivos modificados:**
+- `src/schemas/database.ts` (SetRowSchema) — adiciona `duration_seconds`
+- `src/types/app.ts` (SetDetail) — adiciona `durationSeconds`
+- `src/types/workout.ts` (SetDetailSchema) — adiciona `durationSeconds`
+- `src/types/supabase.ts` — regerado via MCP Supabase após a migration
+- `src/components/workout/SetInputRow.tsx` — delega para `PlankSetInput` se `isPlank`
+- `src/components/ExerciseEditor/SetDetailsSection.tsx` — troca "Reps" por "Tempo alvo (s)" se `isPlank`
+- `src/components/workout/WorkoutTimerContext.tsx` — estado ganha campo `mode: 'rest' | 'plank'`
+- `src/components/workout/RestTimerOverlay.tsx` — ajusta copy/título conforme `mode` (renomear pra `WorkoutTimerOverlay.tsx` na mesma PR)
+- Todos os locais que hoje montam string "X reps × Y kg" passam a usar `formatSetSummary`. Durante implementação, o plano vai mapear cada ocorrência via `grep` e listá-las explicitamente.
+
+**Princípio de isolamento:** `PlankSetInput` é um componente fechado — recebe props (exercício, série atual, peso corporal do usuário, callback de salvar), gerencia timer internamente, retorna `{ weight, duration_seconds }`. Pode ser testado em isolamento, e o `SetInputRow` não precisa saber nada sobre timer ou tempo.
+
+## 5. Schema e banco de dados
+
+### Migration
+
+```sql
+ALTER TABLE sets
+  ADD COLUMN duration_seconds INTEGER NULL
+  CHECK (duration_seconds IS NULL OR duration_seconds > 0);
+COMMENT ON COLUMN sets.duration_seconds
+  IS 'Duração em segundos para exercícios isométricos (ex: Prancha). NULL para exercícios baseados em reps.';
+```
+
+Aditiva e nullable — sem downtime, sem quebrar sets existentes.
+
+### Schemas Zod
+
+`SetRowSchema` (`src/schemas/database.ts`):
+```ts
+duration_seconds: z.number().int().positive().nullable()
+```
+
+`SetDetail` (`src/types/app.ts`) e `SetDetailSchema` (`src/types/workout.ts`):
+```ts
+durationSeconds: number | null
+```
+
+### Invariante (no código, não no banco)
+
+Se `isPlank(exercise.name) === true`, a série gravada tem `duration_seconds != null` e `reps == null`. Caso contrário, `duration_seconds == null` e `reps != null`. Essa regra vive dentro do `PlankSetInput` (nunca grava reps) e `SetInputRow` (nunca grava duration).
+
+### Sem backfill
+
+Sets antigos de Prancha (com tempo em `reps`) continuam como estão. O `formatSetSummary` faz fallback:
+```ts
+if (isPlank(ex.name)) {
+  const sec = set.duration_seconds ?? Number(set.reps ?? 0);
+  return `${sec}s × ${set.weight}kg`;
+}
+```
+
+## 6. UI
+
+### 6.1 — `PlankSetInput` (modal de série)
+
+**Estado padrão:**
+
+```
+┌──────────────────────────────────────────────────┐
+│ Série 1                                          │
+│                                                  │
+│ Peso corporal (kg)     Tempo alvo (s)            │
+│ [ 82     ]             [ 60     ]                │
+│                                                  │
+│        [  ▶ Iniciar (60s)  ]                     │
+└──────────────────────────────────────────────────┘
+```
+
+**Durante countdown:**
+
+```
+┌──────────────────────────────────────────────────┐
+│ Série 1 • Prancha em andamento                   │
+│                                                  │
+│              00:43                               │
+│         ⸺⸺⸺⸺⸺⸺⸺ 72%                             │
+│                                                  │
+│        [  ⏹ Parar  ]                             │
+└──────────────────────────────────────────────────┘
+```
+
+**Comportamento:**
+
+- Ao montar: `weight` pré-preenche com `settings.bodyWeightKg`. Se for `null`, campo fica vazio com mensagem inline: *"Cadastre seu peso no [perfil](link) para auto-preenchimento"*. O usuário pode prosseguir mesmo sem peso (salva `weight = null`).
+- `duration_seconds` pré-preenche com valor configurado na ficha (template) via `SetDetailsSection`. Se a template não define (ex: Prancha adicionada sem ajuste), campo fica vazio e o usuário digita.
+- Clicar **Iniciar**: inicia countdown via `WorkoutTimerContext.startTimer({ seconds: meta, mode: 'plank', onComplete })`. Desabilita edição dos campos durante a série. Dispara `haptics.impact('light')`.
+- **Timer zera**: salva série com `duration_seconds = meta`, `weight = valor do input`, `reps = null`, `completed = true`. Dispara som + vibração + notificação nativa (herdado do timer de descanso).
+- Clicar **Parar antes**: salva série com `duration_seconds = metaSeconds - remainingSeconds` (tempo efetivamente aguentado), `completed = true`. Sem flag de "falhou" — registra o que aguentou, de forma honesta.
+- **Sem botão Cancelar**: se começou, conta.
+
+### 6.2 — `SetDetailsSection` (editor de ficha/template)
+
+Quando `isPlank(exercise.name)`:
+- Campo "Carga (kg)" → label muda para "Peso corporal (kg)" com hint "Auto-preenchido no treino"
+- Campo "Reps" → substituído por "Tempo alvo (s)"
+- Campo "RPE" → mantém
+
+Usuário monta a ficha como "Prancha 3 séries × 60s".
+
+### 6.3 — Histórico / visualização
+
+Helper `formatSetSummary(set, exercise)` centraliza a formatação. Qualquer local que hoje monta "X reps × Y kg" passa a usar o helper — fica na mesma PR.
+
+- Prancha com `duration_seconds != null` → `"60s × 82 kg"`
+- Prancha legado (sem `duration_seconds`, `reps = "60"`) → `"60s × 82 kg"` (via fallback)
+- Outros exercícios → comportamento atual (`"10 × 80 kg"`)
+
+## 7. Timer (reuso da infra existente)
+
+**Não criar `ExecutionTimerOverlay` novo.** O `WorkoutTimerContext` + `RestTimerOverlay` já fazem countdown, som, vibração, notificação nativa via Capacitor e background task (tela trancada). A diferença é só semântica.
+
+**Mudanças:**
+- `WorkoutTimerContext`: estado ganha `mode: 'rest' | 'plank'` e `onComplete?: () => void`.
+- `RestTimerOverlay` (renomear para `WorkoutTimerOverlay.tsx`): copy do título muda conforme `mode` ("Descanso" vs "Prancha").
+- Som, vibração, notificação, comportamento em background — tudo compartilhado.
+
+**Fluxo:**
+1. `PlankSetInput` → `startTimer({ seconds: meta, mode: 'plank', onComplete: () => saveSet(...) })`
+2. `WorkoutTimerContext` inicia countdown idêntico ao rest.
+3. `WorkoutTimerOverlay` ajusta título conforme `mode`.
+4. Ao zerar: dispara `onComplete` (salva série) + som/vibração/notificação existentes.
+5. Em background (app minimizado ou tela trancada): timer continua e alerta via notificação local.
+
+**Por que não criar overlay novo:** duplicaria lógica crítica de timing em iOS/Android, que historicamente é sensível. Menos arquivos, menos duplicação.
+
+## 8. Testes
+
+### Unitários (Vitest)
+
+`src/utils/__tests__/exerciseTracking.test.ts`:
+- `isPlank("Prancha")` → `true`
+- `isPlank("Prancha lateral")` → `true`
+- `isPlank("Plank")` → `true`
+- `isPlank("Supino")` → `false`
+- `isPlank("")` → `false`
+- `isPlank(null as any)` → `false`
+
+`src/utils/__tests__/formatSetSummary.test.ts`:
+- Prancha com `duration_seconds=60, weight=82` → `"60s × 82 kg"`
+- Prancha legado (sem `duration_seconds`, `reps="60"`) → `"60s × 82 kg"`
+- Supino com `reps="10", weight=80` → `"10 × 80 kg"` (não regride)
+
+### Componente (Vitest + Testing Library)
+
+`src/components/workout/__tests__/PlankSetInput.test.tsx` (mocka `WorkoutTimerContext`):
+- Renderiza peso vazio + mensagem quando `bodyWeightKg` é null
+- Renderiza peso preenchido quando cadastrado
+- Clicar Iniciar chama `startTimer({seconds, mode:'plank', onComplete})`
+- Clicar Parar durante timer salva série com tempo decorrido real
+- `onComplete` (disparado pelo context ao zerar) salva série com tempo alvo
+
+### E2E (Playwright)
+
+`e2e/plank-set.spec.ts`:
+- Usuário com peso cadastrado entra em ficha contendo Prancha → inicia série → timer conta → zera → histórico mostra "60s × Xkg"
+
+### Regressão manual (não-automatizada)
+
+Antes de merge: exercício não-prancha (ex: Supino) continua exatamente igual — modal com reps/peso, sem campos novos aparecendo.
+
+## 9. Checklist de deploy
+
+1. Aplicar migration em branch Supabase (MCP `apply_migration`) — verificar em `list_migrations`
+2. `mcp__supabase__generate_typescript_types` → atualiza `src/types/supabase.ts`
+3. `npx tsc --noEmit` → zero erros
+4. ESLint nos arquivos editados com `--max-warnings 0`
+5. `npm run test:unit` → tudo passando
+6. `npm run scan:secrets` (padrão)
+7. `npm run build` local → sucesso
+8. Merge via PR (não direto em main) → Vercel CI/CD faz deploy web
+9. `npm run cap:sync` apenas se for rodar em device local — nenhuma mudança nativa neste spec
+
+## 10. Rollback
+
+Migration aditiva e nullable → rollback:
+```sql
+ALTER TABLE sets DROP COLUMN duration_seconds;
+```
++ revert do PR.
+
+Sets criados com `duration_seconds` perdem o tempo (não caem para `reps`), mas nenhum outro registro quebra e nenhum dado antigo é afetado.

--- a/docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md
+++ b/docs/superpowers/specs/2026-04-20-prancha-isometrica-design.md
@@ -62,8 +62,8 @@ Helper único `isPlank(exerciseName: string): boolean` em `src/utils/exerciseTra
 - `src/types/supabase.ts` — regerado via MCP Supabase após a migration
 - `src/components/workout/SetInputRow.tsx` — delega para `PlankSetInput` se `isPlank`
 - `src/components/ExerciseEditor/SetDetailsSection.tsx` — troca "Reps" por "Tempo alvo (s)" se `isPlank`
-- `src/components/workout/WorkoutTimerContext.tsx` — estado ganha campo `mode: 'rest' | 'plank'`
-- `src/components/workout/RestTimerOverlay.tsx` — ajusta copy/título conforme `mode` (renomear pra `WorkoutTimerOverlay.tsx` na mesma PR)
+- `src/components/workout/ActiveWorkoutContext.tsx` (e componentes vinculados) — `startTimer` aceita `kind: 'rest' | 'plank'` e callback `onComplete`
+- `src/components/workout/RestTimerOverlay.tsx` — copy/título condicional conforme `context.kind`
 - Todos os locais que hoje montam string "X reps × Y kg" passam a usar `formatSetSummary`. Durante implementação, o plano vai mapear cada ocorrência via `grep` e listá-las explicitamente.
 
 **Princípio de isolamento:** `PlankSetInput` é um componente fechado — recebe props (exercício, série atual, peso corporal do usuário, callback de salvar), gerencia timer internamente, retorna `{ weight, duration_seconds }`. Pode ser testado em isolamento, e o `SetInputRow` não precisa saber nada sobre timer ou tempo.
@@ -166,19 +166,18 @@ Helper `formatSetSummary(set, exercise)` centraliza a formatação. Qualquer loc
 
 ## 7. Timer (reuso da infra existente)
 
-**Não criar `ExecutionTimerOverlay` novo.** O `WorkoutTimerContext` + `RestTimerOverlay` já fazem countdown, som, vibração, notificação nativa via Capacitor e background task (tela trancada). A diferença é só semântica.
+**Não criar novo overlay de timer.** O `RestTimerOverlay` + a função `startTimer(seconds, context)` exposta pelo `ActiveWorkoutContext` já fazem countdown, som, vibração, notificação nativa via Capacitor e funcionam em background (tela trancada). A diferença é só semântica.
 
 **Mudanças:**
-- `WorkoutTimerContext`: estado ganha `mode: 'rest' | 'plank'` e `onComplete?: () => void`.
-- `RestTimerOverlay` (renomear para `WorkoutTimerOverlay.tsx`): copy do título muda conforme `mode` ("Descanso" vs "Prancha").
-- Som, vibração, notificação, comportamento em background — tudo compartilhado.
+- `ActiveWorkoutContext.startTimer(seconds, context)`: `context.kind` hoje aceita `'rest'`; passa a aceitar `'plank'` também. O context ganha campo opcional `onComplete?: () => void` chamado quando o timer zera.
+- `RestTimerOverlay`: o copy do título e labels usa `context.kind` para decidir entre "Descanso" e "Prancha". A lógica de timing, som, vibração, background — fica inalterada.
 
 **Fluxo:**
-1. `PlankSetInput` → `startTimer({ seconds: meta, mode: 'plank', onComplete: () => saveSet(...) })`
-2. `WorkoutTimerContext` inicia countdown idêntico ao rest.
-3. `WorkoutTimerOverlay` ajusta título conforme `mode`.
-4. Ao zerar: dispara `onComplete` (salva série) + som/vibração/notificação existentes.
-5. Em background (app minimizado ou tela trancada): timer continua e alerta via notificação local.
+1. `PlankSetInput` chama `startTimer(meta, { kind: 'plank', key, exerciseName, onComplete: saveSet })`
+2. `RestTimerOverlay` aparece e renderiza com copy de "Prancha".
+3. Ao zerar: dispara `onComplete` (salva série com `duration_seconds = meta`) + som/vibração/notificação existentes.
+4. Se o usuário clica "Parar" dentro do `PlankSetInput` antes do fim: salva série com `duration_seconds = meta - timeLeft` e cancela o timer.
+5. Em background (app minimizado ou tela trancada): timer continua e alerta via notificação local — herdado do rest timer.
 
 **Por que não criar overlay novo:** duplicaria lógica crítica de timing em iOS/Android, que historicamente é sensível. Menos arquivos, menos duplicação.
 

--- a/e2e/authenticated-plank-set.spec.ts
+++ b/e2e/authenticated-plank-set.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Authenticated E2E: Plank Set Input
+ *
+ * Valida que o modal de série para o exercício Prancha exibe campos específicos
+ * (Peso corporal + Tempo alvo) em vez dos inputs padrão (Peso + Reps).
+ * Defensivo: se o ambiente E2E não tiver uma ficha com Prancha, o teste vira no-op.
+ */
+test.describe('Prancha Set Input (authenticated)', () => {
+    test('modal de Prancha mostra peso corporal e tempo alvo', async ({ page }) => {
+        await page.goto('/dashboard')
+        await page.waitForTimeout(3000)
+
+        // Procurar por qualquer elemento com texto "Prancha" ou "plank"
+        const plankTriggers = page.locator('text=/prancha/i')
+        const plankCount = await plankTriggers.count()
+
+        if (plankCount === 0) {
+            // Sem ficha de Prancha no ambiente — no-op (igual aos outros specs defensivos)
+            return
+        }
+
+        // Clicar para navegar para o treino que contém Prancha
+        await plankTriggers.first().click()
+        await page.waitForTimeout(2000)
+
+        // Tentar localizar o botão de iniciar o treino (padrão dos outros specs)
+        const startWorkoutBtn = page.locator(
+            'button:has-text("Treinar"), button:has-text("Iniciar treino")',
+        )
+        if ((await startWorkoutBtn.count()) > 0) {
+            await startWorkoutBtn.first().click()
+            await page.waitForTimeout(2000)
+        }
+
+        // Dentro do treino ativo — procurar pelos labels exclusivos do PlankSetInput
+        const pesoCorporal = page.locator(
+            '[aria-label="Peso corporal em kg"], label:has-text("Peso corporal")',
+        )
+        const tempoAlvo = page.locator(
+            '[aria-label="Tempo alvo em segundos"], label:has-text("Tempo alvo")',
+        )
+
+        const pesoCount = await pesoCorporal.count()
+        const tempoCount = await tempoAlvo.count()
+
+        if (pesoCount > 0 && tempoCount > 0) {
+            // Evidência clara do PlankSetInput renderizando
+            await expect(pesoCorporal.first()).toBeVisible()
+            await expect(tempoAlvo.first()).toBeVisible()
+        }
+    })
+
+    test('botão Iniciar dispara o overlay "Prancha em andamento"', async ({ page }) => {
+        await page.goto('/dashboard')
+        await page.waitForTimeout(3000)
+
+        // Mesma lógica defensiva: sem Prancha → no-op
+        const plankTriggers = page.locator('text=/prancha/i')
+        if ((await plankTriggers.count()) === 0) return
+
+        await plankTriggers.first().click()
+        await page.waitForTimeout(2000)
+
+        const startWorkoutBtn = page.locator(
+            'button:has-text("Treinar"), button:has-text("Iniciar treino")',
+        )
+        if ((await startWorkoutBtn.count()) > 0) {
+            await startWorkoutBtn.first().click()
+            await page.waitForTimeout(2000)
+        }
+
+        // Definir tempo curto (5s) para o countdown não bloquear o teste
+        const tempoInput = page.locator('[aria-label="Tempo alvo em segundos"]').first()
+        if ((await tempoInput.count()) === 0) return
+
+        await tempoInput.fill('5')
+
+        // Clicar em Iniciar do PlankSetInput (distingue do "Iniciar treino" pelo contexto)
+        const iniciarBtn = page
+            .locator('button:has-text("Iniciar")')
+            .filter({ hasNotText: 'treino' })
+            .first()
+
+        if ((await iniciarBtn.count()) === 0) return
+
+        await iniciarBtn.click()
+        await page.waitForTimeout(500)
+
+        // O PlankSetInput substitui o form pelo overlay "Prancha em andamento"
+        const plankOverlay = page.locator('text=/prancha em andamento/i')
+        if ((await plankOverlay.count()) > 0) {
+            await expect(plankOverlay.first()).toBeVisible()
+        }
+    })
+})

--- a/src/components/ExerciseEditor.tsx
+++ b/src/components/ExerciseEditor.tsx
@@ -487,6 +487,7 @@ const ExerciseEditor: React.FC<ExerciseEditorProps> = ({ workout, onSave, onCanc
                                                 setDetails={setDetails}
                                                 safeMethod={safeMethod}
                                                 exerciseIndex={index}
+                                                exerciseName={exercise.name || ''}
                                                 onUpdateSetDetail={updateSetDetail}
                                             />
                                         )}

--- a/src/components/ExerciseEditor/SetDetailsSection.tsx
+++ b/src/components/ExerciseEditor/SetDetailsSection.tsx
@@ -3,11 +3,13 @@
 import React from 'react'
 import { Trash2 } from 'lucide-react'
 import type { AdvancedConfig, SetDetail } from './types'
+import { isPlank } from '@/utils/exerciseTracking'
 
 interface SetDetailsSectionProps {
     setDetails: SetDetail[]
     safeMethod: string
     exerciseIndex: number
+    exerciseName?: string
     onUpdateSetDetail: (exerciseIdx: number, setIdx: number, patch: Partial<SetDetail>) => void
 }
 
@@ -15,8 +17,10 @@ export const SetDetailsSection: React.FC<SetDetailsSectionProps> = ({
     setDetails,
     safeMethod,
     exerciseIndex,
+    exerciseName = '',
     onUpdateSetDetail,
 }) => {
+    const isIsoPlank = isPlank(exerciseName)
     if (setDetails.length === 0) return null
 
     return (
@@ -83,22 +87,37 @@ export const SetDetailsSection: React.FC<SetDetailsSectionProps> = ({
                         )) && (
                                 <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
                                     <div>
-                                        <div className="text-[10px] text-neutral-500 uppercase font-bold">Carga (kg)</div>
+                                        <div className="text-[10px] text-neutral-500 uppercase font-bold">
+                                            {isIsoPlank ? 'Peso corporal (kg)' : 'Carga (kg)'}
+                                        </div>
                                         <input
                                             type="number"
-                                            aria-label={`Carga em kg para série ${setIdx + 1}`}
+                                            aria-label={`${isIsoPlank ? 'Peso corporal' : 'Carga'} em kg para série ${setIdx + 1}`}
                                             value={(s?.weight ?? '')}
                                             onChange={(e) => onUpdateSetDetail(exerciseIndex, setIdx, { weight: e.target.value === '' ? null : Number(e.target.value) })}
                                             className="w-full bg-black/30 border border-neutral-700 rounded-lg p-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
                                         />
                                     </div>
                                     <div>
-                                        <div className="text-[10px] text-neutral-500 uppercase font-bold">Reps</div>
+                                        <div className="text-[10px] text-neutral-500 uppercase font-bold">
+                                            {isIsoPlank ? 'Tempo alvo (s)' : 'Reps'}
+                                        </div>
                                         <input
                                             type="text"
-                                            aria-label={`Repetições para série ${setIdx + 1}`}
-                                            value={(s?.reps ?? '')}
-                                            onChange={(e) => onUpdateSetDetail(exerciseIndex, setIdx, { reps: e.target.value })}
+                                            inputMode={isIsoPlank ? 'numeric' : 'decimal'}
+                                            aria-label={isIsoPlank ? `Tempo alvo em segundos para série ${setIdx + 1}` : `Repetições para série ${setIdx + 1}`}
+                                            value={isIsoPlank ? String(s?.durationSeconds ?? '') : String(s?.reps ?? '')}
+                                            onChange={(e) => {
+                                                const v = e.target.value
+                                                if (isIsoPlank) {
+                                                    onUpdateSetDetail(exerciseIndex, setIdx, {
+                                                        durationSeconds: v === '' ? null : Number(v),
+                                                        reps: null,
+                                                    })
+                                                } else {
+                                                    onUpdateSetDetail(exerciseIndex, setIdx, { reps: v })
+                                                }
+                                            }}
                                             className="w-full bg-black/30 border border-neutral-700 rounded-lg p-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500"
                                         />
                                     </div>

--- a/src/components/ExerciseEditor/types.ts
+++ b/src/components/ExerciseEditor/types.ts
@@ -27,6 +27,7 @@ export interface SetDetail {
     reps: string | number | null
     rpe: number | null
     weight: number | null
+    durationSeconds?: number | null
     is_warmup?: boolean
     isWarmup?: boolean
     advanced_config?: AdvancedConfig | AdvancedConfig[] | null

--- a/src/components/workout/ExerciseCard.tsx
+++ b/src/components/workout/ExerciseCard.tsx
@@ -166,7 +166,7 @@ function ExerciseCardInner({ ex, exIdx }: { ex: WorkoutExercise; exIdx: number }
 
     // Isometric exercises (Prancha/Plank) use time-based input instead of reps
     if (isPlank(String(ex?.name ?? ''))) {
-      return <PlankSetInput key={key} ex={ex as UnknownRecord} exIdx={exIdx} setIdx={setIdx} />;
+      return <PlankSetInput key={key} ex={ex as UnknownRecord} exIdx={exIdx} setIdx={setIdx} setsCount={setsCount} />;
     }
 
     // Per-set method override — takes precedence over all automatic detection

--- a/src/components/workout/ExerciseCard.tsx
+++ b/src/components/workout/ExerciseCard.tsx
@@ -25,6 +25,8 @@ import { HELP_TERMS } from '@/utils/help/terms';
 import { parseTrainingNumber } from '@/utils/trainingNumber';
 import { isObject, isClusterConfig, isRestPauseConfig } from './utils';
 import { WorkoutExercise, UnknownRecord } from './types';
+import { isPlank } from '@/utils/exerciseTracking';
+import { PlankSetInput } from './PlankSetInput';
 import ExecutionVideoCapture from '@/components/ExecutionVideoCapture';
 import { logError, logInfo } from '@/lib/logger'
 import { useTeamWorkout } from '@/contexts/TeamWorkoutContext'
@@ -161,6 +163,11 @@ function ExerciseCardInner({ ex, exIdx }: { ex: WorkoutExercise; exIdx: number }
     const key = `${exIdx}-${setIdx}`;
     const log = getLog(key);
     const method = String(ex?.method || '').trim();
+
+    // Isometric exercises (Prancha/Plank) use time-based input instead of reps
+    if (isPlank(String(ex?.name ?? ''))) {
+      return <PlankSetInput key={key} ex={ex as UnknownRecord} exIdx={exIdx} setIdx={setIdx} />;
+    }
 
     // Per-set method override — takes precedence over all automatic detection
     const perSetMethod = String(log.per_set_method || '').trim();

--- a/src/components/workout/PlankSetInput.tsx
+++ b/src/components/workout/PlankSetInput.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useRef, useCallback } from 'react'
+import { Play, Square } from 'lucide-react'
+import { useActiveWorkout } from './ActiveWorkoutContext'
+import { UnknownRecord } from './types'
+
+type Props = {
+  ex: UnknownRecord
+  exIdx: number
+  setIdx: number
+}
+
+export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
+  const { getLog, updateLog, startTimer, getPlannedSet, settings } = useActiveWorkout()
+
+  const key = `${exIdx}-${setIdx}`
+  const weightInputId = `plank-weight-${key}`
+  const durationInputId = `plank-duration-${key}`
+  const log = getLog(key)
+  const plannedSet = getPlannedSet(ex as Parameters<typeof getPlannedSet>[0], setIdx) as { durationSeconds?: number | null } | null
+
+  // Extrai bodyWeightKg do settings (UnknownRecord | null)
+  const rawBw = settings && typeof settings === 'object' ? (settings as Record<string, unknown>).bodyWeightKg : null
+  const bodyWeightKg: number | null =
+    rawBw != null && Number.isFinite(Number(rawBw)) && Number(rawBw) > 0
+      ? Number(rawBw)
+      : null
+
+  const initialWeight =
+    typeof log.weight === 'number' || typeof log.weight === 'string'
+      ? String(log.weight)
+      : bodyWeightKg != null
+        ? String(bodyWeightKg)
+        : ''
+  const initialDuration =
+    log.durationSeconds != null
+      ? String(log.durationSeconds)
+      : plannedSet?.durationSeconds != null
+        ? String(plannedSet.durationSeconds)
+        : ''
+
+  const [weight, setWeight] = useState(initialWeight)
+  const [targetSeconds, setTargetSeconds] = useState(initialDuration)
+  const [isRunning, setIsRunning] = useState(false)
+  const startedAtRef = useRef<number>(0)
+
+  const inputBase =
+    'w-full bg-black/40 border border-neutral-700/80 rounded-xl px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500 focus:border-yellow-500/50'
+
+  const handleStart = useCallback(() => {
+    const sec = Number(targetSeconds)
+    if (!Number.isFinite(sec) || sec <= 0) return
+    startedAtRef.current = Date.now()
+    setIsRunning(true)
+
+    startTimer(sec, {
+      kind: 'plank',
+      key,
+      exerciseName: String(ex?.name ?? '').trim(),
+      onComplete: () => {
+        updateLog(key, {
+          weight: weight === '' ? null : Number(weight),
+          reps: null,
+          durationSeconds: sec,
+          done: true,
+        })
+        setIsRunning(false)
+      },
+    })
+  }, [targetSeconds, startTimer, key, ex, updateLog, weight])
+
+  const handleStop = useCallback(() => {
+    const elapsedMs = Date.now() - startedAtRef.current
+    const aguentou = Math.max(1, Math.round(elapsedMs / 1000))
+    updateLog(key, {
+      weight: weight === '' ? null : Number(weight),
+      reps: null,
+      durationSeconds: aguentou,
+      done: true,
+    })
+    setIsRunning(false)
+  }, [key, updateLog, weight])
+
+  const secondsNum = Number(targetSeconds)
+  const canStart = Number.isFinite(secondsNum) && secondsNum > 0
+
+  if (isRunning) {
+    return (
+      <div className="rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-neutral-300">Série {setIdx + 1} • Prancha em andamento</span>
+          <button
+            type="button"
+            onClick={handleStop}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-red-500/90 text-white text-xs font-black"
+          >
+            <Square size={14} />
+            Parar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80 space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center font-black text-[11px] bg-yellow-500 text-black">
+          {setIdx + 1}
+        </div>
+        <div className="flex-1 grid grid-cols-2 gap-1.5 min-w-0">
+          <div>
+            <label
+              htmlFor={weightInputId}
+              className="text-[10px] uppercase tracking-widest text-neutral-500 font-bold block mb-0.5"
+            >
+              Peso corporal (kg)
+            </label>
+            <input
+              id={weightInputId}
+              aria-label="Peso corporal em kg"
+              inputMode="decimal"
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+              className={inputBase}
+              placeholder="kg"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor={durationInputId}
+              className="text-[10px] uppercase tracking-widest text-neutral-500 font-bold block mb-0.5"
+            >
+              Tempo alvo (s)
+            </label>
+            <input
+              id={durationInputId}
+              aria-label="Tempo alvo em segundos"
+              inputMode="numeric"
+              value={targetSeconds}
+              onChange={(e) => setTargetSeconds(e.target.value)}
+              className={inputBase}
+              placeholder="seg"
+            />
+          </div>
+        </div>
+      </div>
+
+      {bodyWeightKg == null && (
+        <p className="text-[11px] text-amber-400/80 px-1">
+          Cadastre seu peso no perfil para auto-preenchimento.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleStart}
+        disabled={!canStart}
+        className="w-full inline-flex items-center justify-center gap-2 py-2.5 rounded-xl font-black text-sm bg-yellow-500 text-black disabled:bg-neutral-800 disabled:text-neutral-600 transition-all duration-200"
+      >
+        <Play size={16} />
+        Iniciar {canStart ? `(${secondsNum}s)` : ''}
+      </button>
+    </div>
+  )
+}

--- a/src/components/workout/PlankSetInput.tsx
+++ b/src/components/workout/PlankSetInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback } from 'react'
-import { Play, Square } from 'lucide-react'
-import { useActiveWorkout } from './ActiveWorkoutContext'
+import { Check, Play, Square } from 'lucide-react'
+import { useWorkoutContext } from './WorkoutContext'
 import { UnknownRecord } from './types'
 
 type Props = {
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
-  const { getLog, updateLog, startTimer, getPlannedSet, settings } = useActiveWorkout()
+  const { getLog, updateLog, startTimer, getPlannedSet, settings } = useWorkoutContext()
 
   const key = `${exIdx}-${setIdx}`
   const weightInputId = `plank-weight-${key}`
@@ -82,6 +82,9 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
 
   const secondsNum = Number(targetSeconds)
   const canStart = Number.isFinite(secondsNum) && secondsNum > 0
+  const done = !!log.done
+  const loggedDuration =
+    typeof log.durationSeconds === 'number' && log.durationSeconds > 0 ? log.durationSeconds : null
 
   if (isRunning) {
     return (
@@ -101,11 +104,18 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
     )
   }
 
+  const containerClass = done
+    ? 'rounded-xl border px-3 py-2.5 bg-emerald-950/30 border-emerald-500/30 space-y-2'
+    : 'rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80 space-y-2'
+  const badgeClass = done
+    ? 'flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center font-black text-[11px] bg-emerald-500 text-black'
+    : 'flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center font-black text-[11px] bg-yellow-500 text-black'
+
   return (
-    <div className="rounded-xl border px-3 py-2.5 bg-neutral-900/50 border-neutral-800/80 space-y-2">
+    <div className={containerClass}>
       <div className="flex items-center gap-2">
-        <div className="flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center font-black text-[11px] bg-yellow-500 text-black">
-          {setIdx + 1}
+        <div className={badgeClass}>
+          {done ? <Check size={12} /> : setIdx + 1}
         </div>
         <div className="flex-1 grid grid-cols-2 gap-1.5 min-w-0">
           <div>
@@ -151,15 +161,22 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
         </p>
       )}
 
-      <button
-        type="button"
-        onClick={handleStart}
-        disabled={!canStart}
-        className="w-full inline-flex items-center justify-center gap-2 py-2.5 rounded-xl font-black text-sm bg-yellow-500 text-black disabled:bg-neutral-800 disabled:text-neutral-600 transition-all duration-200"
-      >
-        <Play size={16} />
-        Iniciar {canStart ? `(${secondsNum}s)` : ''}
-      </button>
+      {done ? (
+        <div className="w-full inline-flex items-center justify-center gap-2 py-2.5 rounded-xl font-black text-sm bg-emerald-500/20 border border-emerald-500/40 text-emerald-300">
+          <Check size={16} />
+          Concluída {loggedDuration !== null ? `(${loggedDuration}s)` : ''}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={handleStart}
+          disabled={!canStart}
+          className="w-full inline-flex items-center justify-center gap-2 py-2.5 rounded-xl font-black text-sm bg-yellow-500 text-black disabled:bg-neutral-800 disabled:text-neutral-600 transition-all duration-200"
+        >
+          <Play size={16} />
+          Iniciar {canStart ? `(${secondsNum}s)` : ''}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/workout/PlankSetInput.tsx
+++ b/src/components/workout/PlankSetInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback } from 'react'
+import { flushSync } from 'react-dom'
 import { Check, Play, Square } from 'lucide-react'
 import { useWorkoutContext } from './WorkoutContext'
 import { UnknownRecord } from './types'
@@ -7,10 +8,11 @@ type Props = {
   ex: UnknownRecord
   exIdx: number
   setIdx: number
+  setsCount?: number
 }
 
-export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
-  const { getLog, updateLog, startTimer, getPlannedSet, settings } = useWorkoutContext()
+export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx, setsCount }) => {
+  const { getLog, updateLog, startTimer, getPlannedSet, settings, setCollapsed } = useWorkoutContext()
 
   const key = `${exIdx}-${setIdx}`
   const weightInputId = `plank-weight-${key}`
@@ -46,6 +48,30 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
   const inputBase =
     'w-full bg-black/40 border border-neutral-700/80 rounded-xl px-3 py-2 text-sm text-white outline-none focus:ring-1 ring-yellow-500 focus:border-yellow-500/50'
 
+  const collapseAndScroll = useCallback((delay: number) => {
+    setTimeout(() => {
+      try {
+        flushSync(() => {
+          setCollapsed?.((prev: Set<number>) => {
+            const next = new Set(prev)
+            next.add(exIdx)
+            return next
+          })
+        })
+        const firstSetOfNext = document.querySelector<HTMLElement>(`[data-set-first="${exIdx + 1}"]`)
+        const nextCard = document.querySelector<HTMLElement>(`[data-exercise-idx="${exIdx + 1}"]`)
+        const target = firstSetOfNext ?? nextCard
+        target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      } catch { /* silenced */ }
+    }, delay)
+  }, [setCollapsed, exIdx])
+
+  const maybeCollapseIfLastSet = useCallback(() => {
+    if (setsCount != null && setIdx === setsCount - 1) {
+      collapseAndScroll(600)
+    }
+  }, [setsCount, setIdx, collapseAndScroll])
+
   const handleStart = useCallback(() => {
     const sec = Number(targetSeconds)
     if (!Number.isFinite(sec) || sec <= 0) return
@@ -64,9 +90,10 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
           done: true,
         })
         setIsRunning(false)
+        maybeCollapseIfLastSet()
       },
     })
-  }, [targetSeconds, startTimer, key, ex, updateLog, weight])
+  }, [targetSeconds, startTimer, key, ex, updateLog, weight, maybeCollapseIfLastSet])
 
   const handleStop = useCallback(() => {
     const elapsedMs = Date.now() - startedAtRef.current
@@ -78,7 +105,8 @@ export const PlankSetInput: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
       done: true,
     })
     setIsRunning(false)
-  }, [key, updateLog, weight])
+    maybeCollapseIfLastSet()
+  }, [key, updateLog, weight, maybeCollapseIfLastSet])
 
   const secondsNum = Number(targetSeconds)
   const canStart = Number.isFinite(secondsNum) && secondsNum > 0

--- a/src/components/workout/RestTimerOverlay.tsx
+++ b/src/components/workout/RestTimerOverlay.tsx
@@ -11,6 +11,7 @@ interface RestTimerContext {
     exerciseId?: string;
     exerciseName?: string;
     setId?: string;
+    onComplete?: (finalDurationSeconds?: number) => void;
 }
 
 interface RestTimerSettings {
@@ -39,6 +40,10 @@ interface RestTimerOverlayProps {
 }
 
 const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context, onFinish, onStart, onClose: _onClose, settings, autoStartEnabled, onToggleAutoStart }) => {
+    const isPlankMode = context?.kind === 'plank'
+    const overlayTitle = isPlankMode ? 'Prancha' : 'Descanso'
+    const finishedLabel = isPlankMode ? 'Tempo concluído!' : 'Descanso finalizado'
+
     const [timeLeft, setTimeLeft] = useState(0);
     const [isFinished, setIsFinished] = useState(false);
     const [autoStartLocal, setAutoStartLocal] = useState(Boolean(autoStartEnabled));
@@ -263,6 +268,9 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                             tag: 'timer_finished'
                         });
                     }
+                    if (typeof onCompleteRef.current === 'function') {
+                        onCompleteRef.current();
+                    }
                 }
             } else {
                 setTimeLeft(remaining);
@@ -331,9 +339,11 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
     const onStartRef = useRef(onStart);
     const onFinishRef = useRef(onFinish);
     const contextRef = useRef(context);
+    const onCompleteRef = useRef(context?.onComplete);
     onStartRef.current = onStart;
     onFinishRef.current = onFinish;
     contextRef.current = context;
+    onCompleteRef.current = context?.onComplete;
 
     useEffect(() => {
         if (!isFinished) {
@@ -442,7 +452,7 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                 >
                     <div className="text-7xl mb-4">{isSideRest ? '🔄' : '💪'}</div>
                     <h1 className="text-5xl font-black text-white uppercase tracking-tighter">{isSideRest ? 'TROCA!' : 'BORA!'}</h1>
-                    <p className="text-white/80 font-bold mt-2 text-lg">{isSideRest ? 'Agora o outro lado' : 'Descanso finalizado'}</p>
+                    <p className="text-white/80 font-bold mt-2 text-lg">{isSideRest ? 'Agora o outro lado' : finishedLabel}</p>
                 </div>
             )}
 
@@ -489,7 +499,7 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                                 className="text-[7px] font-black uppercase tracking-widest mt-0.5"
                                 style={{ color: isOvertime ? '#ef4444' : isSideRest ? '#3b82f6' : isTransition ? '#f97316' : '#737373' }}
                             >
-                                {isOvertime ? 'extra' : isSideRest ? 'lado' : isTransition ? 'troca' : 'rest'}
+                                {isOvertime ? 'extra' : isSideRest ? 'lado' : isTransition ? 'troca' : overlayTitle.toLowerCase()}
                             </span>
                         </div>
                     </div>

--- a/src/components/workout/SetInputRow.tsx
+++ b/src/components/workout/SetInputRow.tsx
@@ -5,6 +5,8 @@ import { useActiveWorkout } from './ActiveWorkoutContext';
 import { isObject, toNumber } from './utils';
 import { UnknownRecord } from './types';
 import { triggerHaptic } from '@/utils/native/irontracksNative';
+import { isPlank } from '@/utils/exerciseTracking';
+import { PlankSetInput } from './PlankSetInput';
 
 type Props = {
   ex: UnknownRecord;
@@ -24,6 +26,8 @@ export const SetInputRow: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
     startTimer,
     HELP_TERMS,
   } = useActiveWorkout();
+
+  const exerciseName = String(ex?.name ?? '')
 
   const key = `${exIdx}-${setIdx}`;
   const log = getLog(key);
@@ -93,6 +97,11 @@ export const SetInputRow: React.FC<Props> = ({ ex, exIdx, setIdx }) => {
     }
     return () => timers.forEach(clearTimeout);
   }, [done]);
+
+  // Delegate to PlankSetInput for isometric exercises — must be after all hooks
+  if (isPlank(exerciseName)) {
+    return <PlankSetInput ex={ex} exIdx={exIdx} setIdx={setIdx} />
+  }
 
   // Shared input base class — unified palette (no RPE-specific color in idle state)
   const inputBase =

--- a/src/components/workout/__tests__/PlankSetInput.test.tsx
+++ b/src/components/workout/__tests__/PlankSetInput.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PlankSetInput } from '../PlankSetInput'
+
+// Mock do ActiveWorkoutContext
+const mockStartTimer = vi.fn()
+const mockUpdateLog = vi.fn()
+
+vi.mock('../ActiveWorkoutContext', () => ({
+  useActiveWorkout: () => ({
+    getLog: () => ({}),
+    updateLog: mockUpdateLog,
+    startTimer: mockStartTimer,
+    getPlannedSet: () => ({ durationSeconds: 60 }),
+    // settings expõe bodyWeightKg — tipagem é UnknownRecord | null
+    settings: { bodyWeightKg: 82 },
+  }),
+}))
+
+const baseProps = {
+  ex: { name: 'Prancha' },
+  exIdx: 0,
+  setIdx: 0,
+}
+
+describe('PlankSetInput', () => {
+  beforeEach(() => {
+    mockStartTimer.mockReset()
+    mockUpdateLog.mockReset()
+  })
+
+  it('pré-preenche peso com bodyWeightKg das settings', () => {
+    render(<PlankSetInput {...baseProps} />)
+    const weightInput = screen.getByLabelText(/peso corporal/i) as HTMLInputElement
+    expect(weightInput.value).toBe('82')
+  })
+
+  it('pré-preenche tempo alvo com valor da ficha', () => {
+    render(<PlankSetInput {...baseProps} />)
+    const timeInput = screen.getByLabelText(/tempo alvo/i) as HTMLInputElement
+    expect(timeInput.value).toBe('60')
+  })
+
+  it('clicar Iniciar chama startTimer com kind plank e onComplete', () => {
+    render(<PlankSetInput {...baseProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /iniciar/i }))
+    expect(mockStartTimer).toHaveBeenCalledTimes(1)
+    const [seconds, ctx] = mockStartTimer.mock.calls[0] as [number, { kind: string; onComplete: unknown }]
+    expect(seconds).toBe(60)
+    expect(ctx.kind).toBe('plank')
+    expect(typeof ctx.onComplete).toBe('function')
+  })
+})
+
+describe('PlankSetInput — sem peso cadastrado', () => {
+  it('mostra mensagem pedindo para cadastrar peso no perfil', () => {
+    // Override mock: settings sem bodyWeightKg
+    vi.doMock('../ActiveWorkoutContext', () => ({
+      useActiveWorkout: () => ({
+        getLog: () => ({}),
+        updateLog: vi.fn(),
+        startTimer: vi.fn(),
+        getPlannedSet: () => ({ durationSeconds: 60 }),
+        settings: { bodyWeightKg: null },
+      }),
+    }))
+
+    // Renderiza com settings que retornam null para bodyWeightKg
+    // Como vi.doMock não faz re-import automático neste escopo,
+    // testamos diretamente passando um log vazio e settings null mockado via prop
+    // Reimportamos para garantir o módulo fresco
+    vi.resetModules()
+  })
+
+  it('campo peso fica vazio quando bodyWeightKg é null', async () => {
+    // Re-mock com bodyWeightKg null usando vi.mock isolado por importação dinâmica
+    vi.doMock('../ActiveWorkoutContext', () => ({
+      useActiveWorkout: () => ({
+        getLog: () => ({}),
+        updateLog: vi.fn(),
+        startTimer: vi.fn(),
+        getPlannedSet: () => ({ durationSeconds: 60 }),
+        settings: { bodyWeightKg: null },
+      }),
+    }))
+    vi.resetModules()
+    const { PlankSetInput: Fresh } = await import('../PlankSetInput')
+    render(<Fresh {...baseProps} />)
+    const weightInput = screen.getByLabelText(/peso corporal/i) as HTMLInputElement
+    expect(weightInput.value).toBe('')
+    expect(screen.getByText(/cadastre seu peso/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/workout/__tests__/PlankSetInput.test.tsx
+++ b/src/components/workout/__tests__/PlankSetInput.test.tsx
@@ -2,12 +2,12 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PlankSetInput } from '../PlankSetInput'
 
-// Mock do ActiveWorkoutContext
+// Mock do WorkoutContext (mesmo hook usado pelos outros set-renderers)
 const mockStartTimer = vi.fn()
 const mockUpdateLog = vi.fn()
 
-vi.mock('../ActiveWorkoutContext', () => ({
-  useActiveWorkout: () => ({
+vi.mock('../WorkoutContext', () => ({
+  useWorkoutContext: () => ({
     getLog: () => ({}),
     updateLog: mockUpdateLog,
     startTimer: mockStartTimer,
@@ -55,8 +55,8 @@ describe('PlankSetInput', () => {
 describe('PlankSetInput — sem peso cadastrado', () => {
   it('mostra mensagem pedindo para cadastrar peso no perfil', () => {
     // Override mock: settings sem bodyWeightKg
-    vi.doMock('../ActiveWorkoutContext', () => ({
-      useActiveWorkout: () => ({
+    vi.doMock('../WorkoutContext', () => ({
+      useWorkoutContext: () => ({
         getLog: () => ({}),
         updateLog: vi.fn(),
         startTimer: vi.fn(),
@@ -74,8 +74,8 @@ describe('PlankSetInput — sem peso cadastrado', () => {
 
   it('campo peso fica vazio quando bodyWeightKg é null', async () => {
     // Re-mock com bodyWeightKg null usando vi.mock isolado por importação dinâmica
-    vi.doMock('../ActiveWorkoutContext', () => ({
-      useActiveWorkout: () => ({
+    vi.doMock('../WorkoutContext', () => ({
+      useWorkoutContext: () => ({
         getLog: () => ({}),
         updateLog: vi.fn(),
         startTimer: vi.fn(),

--- a/src/components/workout/set-renderers/normalSet.tsx
+++ b/src/components/workout/set-renderers/normalSet.tsx
@@ -170,9 +170,15 @@ export const NormalSet = ({
   const lRpeField    = useInputField(extLRpe,    (v) => updateLog(key, { L_rpe: v }));
   const rRpeField    = useInputField(extRRpe,    (v) => updateLog(key, { R_rpe: v }));
 
-  // Shared input style
+  // Shared input style — weight column (3fr, roomy)
   const inputBase =
     'w-full bg-black/40 border border-neutral-700/80 rounded-xl px-2.5 py-2 text-sm text-white ' +
+    'outline-none focus:ring-1 ring-yellow-500 focus:border-yellow-500/50 transition-all duration-200 ' +
+    'placeholder:text-neutral-600 placeholder:text-xs focus:placeholder:opacity-0';
+  // Compact variant for reps/RPE (narrow 2fr columns) — reduced padding so
+  // 5-char placeholders like "10-12" fit without truncation.
+  const inputCompact =
+    'w-full bg-black/40 border border-neutral-700/80 rounded-xl px-1.5 py-2 text-sm text-white text-center ' +
     'outline-none focus:ring-1 ring-yellow-500 focus:border-yellow-500/50 transition-all duration-200 ' +
     'placeholder:text-neutral-600 placeholder:text-xs focus:placeholder:opacity-0';
 
@@ -378,8 +384,7 @@ export const NormalSet = ({
             className={inputBase}
           />
 
-          {/* Reps — unilateral columns are narrow: use plannedReps AS placeholder
-               instead of stacking an overlay that would collide with "Reps". */}
+          {/* Reps — plannedReps becomes the placeholder (narrow column, compact padding) */}
           <input
             inputMode="decimal"
             aria-label={`Reps lado ${side} – série ${setIdx + 1}`}
@@ -388,10 +393,10 @@ export const NormalSet = ({
             onFocus={repsFld.handleFocus}
             onBlur={repsFld.handleBlur}
             placeholder={plannedReps || repsPlaceholder}
-            className={inputBase}
+            className={inputCompact}
           />
 
-          {/* RPE — same treatment as reps (narrow column, no overlay) */}
+          {/* RPE — same treatment as reps */}
           <input
             inputMode="decimal"
             aria-label={`RPE lado ${side} – série ${setIdx + 1}`}
@@ -400,7 +405,7 @@ export const NormalSet = ({
             onFocus={rpeFld.handleFocus}
             onBlur={rpeFld.handleBlur}
             placeholder={plannedRpe || rpePlaceholder}
-            className={`${inputBase} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60`}
+            className={`${inputCompact} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60`}
           />
 
           {/* Complete side button */}
@@ -482,43 +487,29 @@ export const NormalSet = ({
               className={inputBase}
             />
 
-            {/* reps */}
-            <div className="relative">
-              <input
-                inputMode="decimal"
-                aria-label={`Reps – série ${setIdx + 1}`}
-                value={repsField.value}
-                onChange={repsField.handleChange}
-                onFocus={repsField.handleFocus}
-                onBlur={repsField.handleBlur}
-                placeholder={repsPlaceholder}
-                className={`${inputBase} ${plannedReps ? 'pr-6' : ''}`}
-              />
-              {plannedReps && (
-                <span className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-[9px] font-mono text-neutral-500/60">
-                  {plannedReps}
-                </span>
-              )}
-            </div>
+            {/* reps — plannedReps becomes the placeholder (narrow column, compact padding) */}
+            <input
+              inputMode="decimal"
+              aria-label={`Reps – série ${setIdx + 1}`}
+              value={repsField.value}
+              onChange={repsField.handleChange}
+              onFocus={repsField.handleFocus}
+              onBlur={repsField.handleBlur}
+              placeholder={plannedReps || repsPlaceholder}
+              className={inputCompact}
+            />
 
-            {/* RPE */}
-            <div className="relative">
-              <input
-                inputMode="decimal"
-                aria-label={`RPE – série ${setIdx + 1}`}
-                value={rpeField.value}
-                onChange={rpeField.handleChange}
-                onFocus={rpeField.handleFocus}
-                onBlur={rpeField.handleBlur}
-                placeholder={rpePlaceholder}
-                className={`${inputBase} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60 ${plannedRpe ? 'pr-6' : ''}`}
-              />
-              {plannedRpe && (
-                <span className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-[9px] font-mono text-yellow-600/50">
-                  {plannedRpe}
-                </span>
-              )}
-            </div>
+            {/* RPE — same treatment as reps */}
+            <input
+              inputMode="decimal"
+              aria-label={`RPE – série ${setIdx + 1}`}
+              value={rpeField.value}
+              onChange={rpeField.handleChange}
+              onFocus={rpeField.handleFocus}
+              onBlur={rpeField.handleBlur}
+              placeholder={plannedRpe || rpePlaceholder}
+              className={`${inputCompact} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60`}
+            />
 
             {/* OK button */}
             <button

--- a/src/components/workout/set-renderers/normalSet.tsx
+++ b/src/components/workout/set-renderers/normalSet.tsx
@@ -5,6 +5,7 @@ import { flushSync } from 'react-dom';
 import { parseTrainingNumber } from '@/utils/trainingNumber';
 import { Check, ChevronDown, MessageSquare } from 'lucide-react';
 import { useWorkoutContext } from '../WorkoutContext';
+import { isUnilateralByName } from '@/utils/exerciseTracking';
 import {
   isObject,
   DELOAD_SUGGEST_MODE,
@@ -97,8 +98,12 @@ export const NormalSet = ({
   const plannedSet = getPlannedSet(ex, setIdx);
   const restTime = parseTrainingNumber(ex?.restTime ?? ex?.rest_time);
 
-  // Unilateral config
-  const isUnilateral = !!(ex?.isUnilateral ?? (ex as Record<string, unknown>)?.is_unilateral);
+  // Unilateral config — explicit flag, with fallback to name detection
+  // (catches templates created before the flag existed or imported without it)
+  const explicitUnilateral = ex?.isUnilateral ?? (ex as Record<string, unknown>)?.is_unilateral;
+  const isUnilateral = explicitUnilateral != null
+    ? !!explicitUnilateral
+    : isUnilateralByName(typeof ex?.name === 'string' ? ex.name : null);
   const sideRestTime = parseTrainingNumber((ex as Record<string, unknown>)?.sideRestTime ?? (ex as Record<string, unknown>)?.side_rest_time) ?? 15;
 
   // Set state
@@ -373,43 +378,30 @@ export const NormalSet = ({
             className={inputBase}
           />
 
-          {/* Reps */}
-          <div className="relative">
-            <input
-              inputMode="decimal"
-              aria-label={`Reps lado ${side} – série ${setIdx + 1}`}
-              value={repsFld.value}
-              onChange={repsFld.handleChange}
-              onFocus={repsFld.handleFocus}
-              onBlur={repsFld.handleBlur}
-              placeholder={repsPlaceholder}
-              className={`${inputBase} ${plannedReps ? 'pr-6' : ''}`}
-            />
-            {plannedReps && (
-              <span className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-[9px] font-mono text-neutral-500/60">
-                {plannedReps}
-              </span>
-            )}
-          </div>
+          {/* Reps — unilateral columns are narrow: use plannedReps AS placeholder
+               instead of stacking an overlay that would collide with "Reps". */}
+          <input
+            inputMode="decimal"
+            aria-label={`Reps lado ${side} – série ${setIdx + 1}`}
+            value={repsFld.value}
+            onChange={repsFld.handleChange}
+            onFocus={repsFld.handleFocus}
+            onBlur={repsFld.handleBlur}
+            placeholder={plannedReps || repsPlaceholder}
+            className={inputBase}
+          />
 
-          {/* RPE */}
-          <div className="relative">
-            <input
-              inputMode="decimal"
-              aria-label={`RPE lado ${side} – série ${setIdx + 1}`}
-              value={rpeFld.value}
-              onChange={rpeFld.handleChange}
-              onFocus={rpeFld.handleFocus}
-              onBlur={rpeFld.handleBlur}
-              placeholder={rpePlaceholder}
-              className={`${inputBase} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60 ${plannedRpe ? 'pr-6' : ''}`}
-            />
-            {plannedRpe && (
-              <span className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 text-[9px] font-mono text-yellow-600/50">
-                {plannedRpe}
-              </span>
-            )}
-          </div>
+          {/* RPE — same treatment as reps (narrow column, no overlay) */}
+          <input
+            inputMode="decimal"
+            aria-label={`RPE lado ${side} – série ${setIdx + 1}`}
+            value={rpeFld.value}
+            onChange={rpeFld.handleChange}
+            onFocus={rpeFld.handleFocus}
+            onBlur={rpeFld.handleBlur}
+            placeholder={plannedRpe || rpePlaceholder}
+            className={`${inputBase} text-yellow-400 border-yellow-500/25 placeholder:text-yellow-600/60`}
+          />
 
           {/* Complete side button */}
           <button

--- a/src/components/workout/set-renderers/normalSet.tsx
+++ b/src/components/workout/set-renderers/normalSet.tsx
@@ -422,10 +422,37 @@ export const NormalSet = ({
     );
   };
 
+  // Column header — only on the first set of each exercise, so the user learns
+  // what each input means. After the first set, header is hidden to save space.
+  const renderUnilateralHeader = () => (
+    <div
+      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-500 font-bold"
+      style={{ gridTemplateColumns: '3fr 2fr 2fr auto' }}
+    >
+      <span>Peso (kg)</span>
+      <span className="text-center">Reps</span>
+      <span className="text-center">RPE</span>
+      <span className="w-14" />
+    </div>
+  );
+  const renderBilateralHeader = () => (
+    <div
+      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-500 font-bold"
+      style={{ gridTemplateColumns: '28px 3fr 2fr 2fr auto' }}
+    >
+      <span />
+      <span>Peso (kg)</span>
+      <span className="text-center">Reps</span>
+      <span className="text-center">RPE</span>
+      <span className="w-14" />
+    </div>
+  );
+
   return (
     <div className="space-y-1" key={key}>
       {isUnilateral ? (
         <>
+          {setIdx === 0 && renderUnilateralHeader()}
           {renderSideRow('L', lDone, lWeightField, lRepsField, lRpeField, handleCompleteL, setIdx === 0)}
           {renderSideRow('R', rDone, rWeightField, rRepsField, rRpeField, handleCompleteR, false)}
           {/* Notes button sits below both L+R rows — clear of exercise footer buttons */}
@@ -447,6 +474,8 @@ export const NormalSet = ({
         </>
       ) : (
         /* ── Non-unilateral single row ─────────────────────────────── */
+        <>
+        {setIdx === 0 && renderBilateralHeader()}
         <div
           {...(setIdx === 0 ? { 'data-set-first': exIdx } : {})}
           className={[
@@ -557,6 +586,7 @@ export const NormalSet = ({
             </div>
           )}
         </div>
+        </>
       )}
 
       {/* Notes textarea — shared between L and R */}

--- a/src/hooks/useReportData.ts
+++ b/src/hooks/useReportData.ts
@@ -15,6 +15,7 @@ import { useRef, useState, useEffect, useMemo } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { getKcalEstimate } from '@/utils/calories/kcalClient'
 import { normalizeExerciseKey, calculateTotalVolume } from '@/utils/report/formatters'
+import { isSetCompleted } from '@/utils/report/setCompletion'
 import { estimateCaloriesMet, getBodyweightFraction, DEFAULT_BODY_WEIGHT_KG } from '@/utils/calories/metEstimate'
 import { useCheckins } from './useCheckins'
 import { usePreviousSessionData } from './usePreviousSessionData'
@@ -450,11 +451,7 @@ export const useReportData = ({ session, previousSession, user, settings }: UseR
         for (let sIdx = 0; sIdx < setCount; sIdx++) {
           const key = `${exIdx}-${sIdx}`
           const log = sessionLogs[key]
-          if (!log || typeof log !== 'object') continue
-          const obj = log as AnyObj
-          const w = Number(String(obj?.weight ?? '').replace(',', '.'))
-          const r = Number(String(obj?.reps ?? '').replace(',', '.'))
-          if ((w > 0 || r > 0)) completed++
+          if (isSetCompleted(log)) completed++
         }
       })
       return {

--- a/src/schemas/__tests__/database.set.test.ts
+++ b/src/schemas/__tests__/database.set.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { SetRowSchema } from '../database'
+
+describe('SetRowSchema — duration_seconds', () => {
+  const base = {
+    id: '00000000-0000-0000-0000-000000000001',
+    exercise_id: '00000000-0000-0000-0000-000000000002',
+    weight: 82,
+    reps: null,
+    rpe: null,
+    set_number: 1,
+    completed: true,
+    is_warmup: false,
+    advanced_config: null,
+  }
+
+  it('aceita duration_seconds como número positivo', () => {
+    const parsed = SetRowSchema.parse({ ...base, duration_seconds: 60 })
+    expect(parsed.duration_seconds).toBe(60)
+  })
+
+  it('aceita duration_seconds como null (exercícios de reps)', () => {
+    const parsed = SetRowSchema.parse({ ...base, duration_seconds: null })
+    expect(parsed.duration_seconds).toBeNull()
+  })
+
+  it('rejeita duration_seconds <= 0', () => {
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: 0 })).toThrow()
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: -5 })).toThrow()
+  })
+
+  it('rejeita duration_seconds decimal', () => {
+    expect(() => SetRowSchema.parse({ ...base, duration_seconds: 1.5 })).toThrow()
+  })
+})

--- a/src/schemas/database.ts
+++ b/src/schemas/database.ts
@@ -77,6 +77,7 @@ export const SetRowSchema = z.object({
   completed: z.boolean().default(false),
   is_warmup: z.boolean().nullable(),
   advanced_config: z.unknown().nullable(),
+  duration_seconds: z.number().int().positive().nullable(),
 })
 export const SetSchema = SetRowSchema.transform((row) => ({
   id: row.id,
@@ -88,6 +89,7 @@ export const SetSchema = SetRowSchema.transform((row) => ({
   completed: row.completed,
   isWarmup: row.is_warmup,
   advancedConfig: row.advanced_config,
+  durationSeconds: row.duration_seconds,
 }))
 export type SetRow = z.infer<typeof SetRowSchema>
 export type Set = z.infer<typeof SetSchema>

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -31,6 +31,7 @@ export interface SetDetail {
   isWarmup: boolean;
   advancedConfig: AdvancedConfig | AdvancedConfig[] | null;
   completed?: boolean;
+  durationSeconds?: number | null;
   it_auto?: {
     source: string;
     kind: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,35 +1,4145 @@
-export type DropSetStep = {
-  weight: number | null
-  reps: string | null
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "13.0.5"
+  }
+  public: {
+    Tables: {
+      access_requests: {
+        Row: {
+          birth_date: string | null
+          created_at: string
+          cref: string | null
+          email: string
+          full_name: string
+          id: string
+          phone: string | null
+          role_requested: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          birth_date?: string | null
+          created_at?: string
+          cref?: string | null
+          email: string
+          full_name: string
+          id?: string
+          phone?: string | null
+          role_requested?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          birth_date?: string | null
+          created_at?: string
+          cref?: string | null
+          email?: string
+          full_name?: string
+          id?: string
+          phone?: string | null
+          role_requested?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      active_workout_sessions: {
+        Row: {
+          started_at: string
+          state: Json
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          started_at?: string
+          state?: Json
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          started_at?: string
+          state?: Json
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "active_workout_sessions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      admin_emails: {
+        Row: {
+          email: string
+        }
+        Insert: {
+          email: string
+        }
+        Update: {
+          email?: string
+        }
+        Relationships: []
+      }
+      app_payments: {
+        Row: {
+          amount_cents: number
+          asaas_payment_id: string | null
+          billing_type: string | null
+          created_at: string
+          currency: string
+          due_date: string | null
+          id: string
+          invoice_url: string | null
+          paid_at: string | null
+          pix_payload: string | null
+          pix_qr_code: string | null
+          plan_id: string | null
+          provider: string
+          provider_payment_id: string | null
+          raw: Json
+          status: string
+          subscription_id: string | null
+          user_id: string
+        }
+        Insert: {
+          amount_cents: number
+          asaas_payment_id?: string | null
+          billing_type?: string | null
+          created_at?: string
+          currency?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          provider?: string
+          provider_payment_id?: string | null
+          raw?: Json
+          status?: string
+          subscription_id?: string | null
+          user_id: string
+        }
+        Update: {
+          amount_cents?: number
+          asaas_payment_id?: string | null
+          billing_type?: string | null
+          created_at?: string
+          currency?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          provider?: string
+          provider_payment_id?: string | null
+          raw?: Json
+          status?: string
+          subscription_id?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "app_payments_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "app_plans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "app_payments_subscription_id_fkey"
+            columns: ["subscription_id"]
+            isOneToOne: false
+            referencedRelation: "app_subscriptions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      app_plans: {
+        Row: {
+          created_at: string
+          currency: string
+          description: string | null
+          features: Json
+          id: string
+          interval: string
+          limits: Json | null
+          name: string
+          price_cents: number
+          sort_order: number
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          features?: Json
+          id: string
+          interval: string
+          limits?: Json | null
+          name: string
+          price_cents: number
+          sort_order?: number
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          features?: Json
+          id?: string
+          interval?: string
+          limits?: Json | null
+          name?: string
+          price_cents?: number
+          sort_order?: number
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      app_subscriptions: {
+        Row: {
+          asaas_customer_id: string | null
+          asaas_subscription_id: string | null
+          cancel_at_period_end: boolean
+          created_at: string
+          current_period_end: string | null
+          current_period_start: string | null
+          id: string
+          metadata: Json
+          plan_id: string
+          provider: string
+          provider_customer_id: string | null
+          provider_subscription_id: string | null
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          asaas_customer_id?: string | null
+          asaas_subscription_id?: string | null
+          cancel_at_period_end?: boolean
+          created_at?: string
+          current_period_end?: string | null
+          current_period_start?: string | null
+          id?: string
+          metadata?: Json
+          plan_id: string
+          provider?: string
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          asaas_customer_id?: string | null
+          asaas_subscription_id?: string | null
+          cancel_at_period_end?: boolean
+          created_at?: string
+          current_period_end?: string | null
+          current_period_start?: string | null
+          id?: string
+          metadata?: Json
+          plan_id?: string
+          provider?: string
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "app_subscriptions_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "app_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      appointments: {
+        Row: {
+          coach_id: string
+          created_at: string
+          end_time: string
+          id: string
+          notes: string | null
+          start_time: string
+          student_id: string | null
+          title: string
+          type: string
+        }
+        Insert: {
+          coach_id: string
+          created_at?: string
+          end_time: string
+          id?: string
+          notes?: string | null
+          start_time: string
+          student_id?: string | null
+          title: string
+          type: string
+        }
+        Update: {
+          coach_id?: string
+          created_at?: string
+          end_time?: string
+          id?: string
+          notes?: string | null
+          start_time?: string
+          student_id?: string | null
+          title?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "appointments_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "students"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      asaas_customers: {
+        Row: {
+          asaas_customer_id: string
+          created_at: string
+          user_id: string
+        }
+        Insert: {
+          asaas_customer_id: string
+          created_at?: string
+          user_id: string
+        }
+        Update: {
+          asaas_customer_id?: string
+          created_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      asaas_webhook_events: {
+        Row: {
+          asaas_event_id: string | null
+          event_type: string | null
+          id: string
+          payload: Json
+          payment_id: string | null
+          processed_at: string | null
+          processing_error: string | null
+          received_at: string
+        }
+        Insert: {
+          asaas_event_id?: string | null
+          event_type?: string | null
+          id?: string
+          payload: Json
+          payment_id?: string | null
+          processed_at?: string | null
+          processing_error?: string | null
+          received_at?: string
+        }
+        Update: {
+          asaas_event_id?: string | null
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          payment_id?: string | null
+          processed_at?: string | null
+          processing_error?: string | null
+          received_at?: string
+        }
+        Relationships: []
+      }
+      assessments: {
+        Row: {
+          abdominal_skinfold: number | null
+          age: number | null
+          arm: number | null
+          arm_circ: number | null
+          arm_circ_left: number | null
+          arm_circ_right: number | null
+          assessment_date: string | null
+          bf: number | null
+          biceps_skinfold: number | null
+          biceps_skinfold_left: number | null
+          biceps_skinfold_right: number | null
+          bmi: number | null
+          bmr: number | null
+          body_fat_percentage: number | null
+          calf_circ: number | null
+          calf_circ_left: number | null
+          calf_circ_right: number | null
+          calf_skinfold: number | null
+          chest_circ: number | null
+          created_at: string | null
+          date: string | null
+          fat_mass: number | null
+          gender: string | null
+          height: number | null
+          hip_circ: number | null
+          id: string
+          lean_mass: number | null
+          midaxillary_skinfold: number | null
+          notes: string | null
+          observations: string | null
+          pdf_url: string | null
+          pectoral_skinfold: number | null
+          student_id: string | null
+          subscapular_skinfold: number | null
+          sum7: number | null
+          suprailiac_skinfold: number | null
+          tdee: number | null
+          thigh_circ: number | null
+          thigh_circ_left: number | null
+          thigh_circ_right: number | null
+          thigh_skinfold: number | null
+          trainer_id: string | null
+          triceps_skinfold: number | null
+          triceps_skinfold_left: number | null
+          triceps_skinfold_right: number | null
+          updated_at: string | null
+          user_id: string | null
+          waist: number | null
+          waist_circ: number | null
+          weight: number | null
+        }
+        Insert: {
+          abdominal_skinfold?: number | null
+          age?: number | null
+          arm?: number | null
+          arm_circ?: number | null
+          arm_circ_left?: number | null
+          arm_circ_right?: number | null
+          assessment_date?: string | null
+          bf?: number | null
+          biceps_skinfold?: number | null
+          biceps_skinfold_left?: number | null
+          biceps_skinfold_right?: number | null
+          bmi?: number | null
+          bmr?: number | null
+          body_fat_percentage?: number | null
+          calf_circ?: number | null
+          calf_circ_left?: number | null
+          calf_circ_right?: number | null
+          calf_skinfold?: number | null
+          chest_circ?: number | null
+          created_at?: string | null
+          date?: string | null
+          fat_mass?: number | null
+          gender?: string | null
+          height?: number | null
+          hip_circ?: number | null
+          id?: string
+          lean_mass?: number | null
+          midaxillary_skinfold?: number | null
+          notes?: string | null
+          observations?: string | null
+          pdf_url?: string | null
+          pectoral_skinfold?: number | null
+          student_id?: string | null
+          subscapular_skinfold?: number | null
+          sum7?: number | null
+          suprailiac_skinfold?: number | null
+          tdee?: number | null
+          thigh_circ?: number | null
+          thigh_circ_left?: number | null
+          thigh_circ_right?: number | null
+          thigh_skinfold?: number | null
+          trainer_id?: string | null
+          triceps_skinfold?: number | null
+          triceps_skinfold_left?: number | null
+          triceps_skinfold_right?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+          waist?: number | null
+          waist_circ?: number | null
+          weight?: number | null
+        }
+        Update: {
+          abdominal_skinfold?: number | null
+          age?: number | null
+          arm?: number | null
+          arm_circ?: number | null
+          arm_circ_left?: number | null
+          arm_circ_right?: number | null
+          assessment_date?: string | null
+          bf?: number | null
+          biceps_skinfold?: number | null
+          biceps_skinfold_left?: number | null
+          biceps_skinfold_right?: number | null
+          bmi?: number | null
+          bmr?: number | null
+          body_fat_percentage?: number | null
+          calf_circ?: number | null
+          calf_circ_left?: number | null
+          calf_circ_right?: number | null
+          calf_skinfold?: number | null
+          chest_circ?: number | null
+          created_at?: string | null
+          date?: string | null
+          fat_mass?: number | null
+          gender?: string | null
+          height?: number | null
+          hip_circ?: number | null
+          id?: string
+          lean_mass?: number | null
+          midaxillary_skinfold?: number | null
+          notes?: string | null
+          observations?: string | null
+          pdf_url?: string | null
+          pectoral_skinfold?: number | null
+          student_id?: string | null
+          subscapular_skinfold?: number | null
+          sum7?: number | null
+          suprailiac_skinfold?: number | null
+          tdee?: number | null
+          thigh_circ?: number | null
+          thigh_circ_left?: number | null
+          thigh_circ_right?: number | null
+          thigh_skinfold?: number | null
+          trainer_id?: string | null
+          triceps_skinfold?: number | null
+          triceps_skinfold_left?: number | null
+          triceps_skinfold_right?: number | null
+          updated_at?: string | null
+          user_id?: string | null
+          waist?: number | null
+          waist_circ?: number | null
+          weight?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assessments_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assessments_trainer_id_fkey"
+            columns: ["trainer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      audit_events: {
+        Row: {
+          action: string
+          actor_email: string | null
+          actor_id: string | null
+          actor_role: string | null
+          created_at: string
+          entity_id: string | null
+          entity_type: string
+          id: number
+          metadata: Json
+        }
+        Insert: {
+          action: string
+          actor_email?: string | null
+          actor_id?: string | null
+          actor_role?: string | null
+          created_at?: string
+          entity_id?: string | null
+          entity_type: string
+          id?: number
+          metadata?: Json
+        }
+        Update: {
+          action?: string
+          actor_email?: string | null
+          actor_id?: string | null
+          actor_role?: string | null
+          created_at?: string
+          entity_id?: string | null
+          entity_type?: string
+          id?: number
+          metadata?: Json
+        }
+        Relationships: []
+      }
+      cardio_tracks: {
+        Row: {
+          avg_pace_min_km: number | null
+          calories_estimated: number | null
+          created_at: string | null
+          distance_meters: number | null
+          duration_seconds: number | null
+          finished_at: string | null
+          id: string
+          max_speed_kmh: number | null
+          route: Json | null
+          started_at: string | null
+          user_id: string
+          workout_id: string | null
+        }
+        Insert: {
+          avg_pace_min_km?: number | null
+          calories_estimated?: number | null
+          created_at?: string | null
+          distance_meters?: number | null
+          duration_seconds?: number | null
+          finished_at?: string | null
+          id?: string
+          max_speed_kmh?: number | null
+          route?: Json | null
+          started_at?: string | null
+          user_id: string
+          workout_id?: string | null
+        }
+        Update: {
+          avg_pace_min_km?: number | null
+          calories_estimated?: number | null
+          created_at?: string | null
+          distance_meters?: number | null
+          duration_seconds?: number | null
+          finished_at?: string | null
+          id?: string
+          max_speed_kmh?: number | null
+          route?: Json | null
+          started_at?: string | null
+          user_id?: string
+          workout_id?: string | null
+        }
+        Relationships: []
+      }
+      client_error_events: {
+        Row: {
+          created_at: string
+          id: number
+          kind: string
+          message: string
+          meta: Json
+          stack: string | null
+          url: string | null
+          user_agent: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          kind: string
+          message: string
+          meta?: Json
+          stack?: string | null
+          url?: string | null
+          user_agent?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          kind?: string
+          message?: string
+          meta?: Json
+          stack?: string | null
+          url?: string | null
+          user_agent?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "client_error_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      coach_inbox_states: {
+        Row: {
+          coach_id: string
+          created_at: string
+          id: string
+          kind: string
+          snooze_until: string | null
+          status: string
+          student_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          coach_id: string
+          created_at?: string
+          id?: string
+          kind: string
+          snooze_until?: string | null
+          status?: string
+          student_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          coach_id?: string
+          created_at?: string
+          id?: string
+          kind?: string
+          snooze_until?: string | null
+          status?: string
+          student_user_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      daily_nutrition_logs: {
+        Row: {
+          calories: number
+          carbs: number
+          created_at: string
+          date: string
+          fat: number
+          protein: number
+          updated_at: string
+          user_id: string
+          water_ml: number
+        }
+        Insert: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          date: string
+          fat?: number
+          protein?: number
+          updated_at?: string
+          user_id: string
+          water_ml?: number
+        }
+        Update: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          date?: string
+          fat?: number
+          protein?: number
+          updated_at?: string
+          user_id?: string
+          water_ml?: number
+        }
+        Relationships: []
+      }
+      device_push_tokens: {
+        Row: {
+          created_at: string
+          device_id: string | null
+          last_seen_at: string | null
+          platform: string
+          token: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          device_id?: string | null
+          last_seen_at?: string | null
+          platform: string
+          token: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          device_id?: string | null
+          last_seen_at?: string | null
+          platform?: string
+          token?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      direct_channels: {
+        Row: {
+          created_at: string | null
+          id: string
+          last_message_at: string | null
+          user1_id: string
+          user2_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          last_message_at?: string | null
+          user1_id: string
+          user2_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          last_message_at?: string | null
+          user1_id?: string
+          user2_id?: string
+        }
+        Relationships: []
+      }
+      direct_messages: {
+        Row: {
+          channel_id: string
+          content: string
+          created_at: string | null
+          id: string
+          is_read: boolean | null
+          sender_id: string
+        }
+        Insert: {
+          channel_id: string
+          content: string
+          created_at?: string | null
+          id?: string
+          is_read?: boolean | null
+          sender_id: string
+        }
+        Update: {
+          channel_id?: string
+          content?: string
+          created_at?: string | null
+          id?: string
+          is_read?: boolean | null
+          sender_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "direct_messages_channel_id_fkey"
+            columns: ["channel_id"]
+            isOneToOne: false
+            referencedRelation: "direct_channels"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      error_reports: {
+        Row: {
+          app_version: string | null
+          created_at: string
+          id: string
+          message: string
+          meta: Json
+          pathname: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          source: string | null
+          stack: string | null
+          status: Database["public"]["Enums"]["error_report_status"]
+          updated_at: string
+          url: string | null
+          user_agent: string | null
+          user_email: string | null
+          user_id: string
+        }
+        Insert: {
+          app_version?: string | null
+          created_at?: string
+          id?: string
+          message: string
+          meta?: Json
+          pathname?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source?: string | null
+          stack?: string | null
+          status?: Database["public"]["Enums"]["error_report_status"]
+          updated_at?: string
+          url?: string | null
+          user_agent?: string | null
+          user_email?: string | null
+          user_id: string
+        }
+        Update: {
+          app_version?: string | null
+          created_at?: string
+          id?: string
+          message?: string
+          meta?: Json
+          pathname?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          source?: string | null
+          stack?: string | null
+          status?: Database["public"]["Enums"]["error_report_status"]
+          updated_at?: string
+          url?: string | null
+          user_agent?: string | null
+          user_email?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      exercise_alias_jobs: {
+        Row: {
+          alias: string
+          attempts: number
+          created_at: string
+          id: string
+          last_error: string | null
+          normalized_alias: string
+          processed_at: string | null
+          resolved_canonical_id: string | null
+          resolved_canonical_name: string | null
+          resolved_confidence: number | null
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          alias: string
+          attempts?: number
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          normalized_alias: string
+          processed_at?: string | null
+          resolved_canonical_id?: string | null
+          resolved_canonical_name?: string | null
+          resolved_confidence?: number | null
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          alias?: string
+          attempts?: number
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          normalized_alias?: string
+          processed_at?: string | null
+          resolved_canonical_id?: string | null
+          resolved_canonical_name?: string | null
+          resolved_confidence?: number | null
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      exercise_aliases: {
+        Row: {
+          alias: string
+          canonical_id: string
+          confidence: number
+          created_at: string
+          id: string
+          needs_review: boolean
+          normalized_alias: string
+          source: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          alias: string
+          canonical_id: string
+          confidence?: number
+          created_at?: string
+          id?: string
+          needs_review?: boolean
+          normalized_alias: string
+          source?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          alias?: string
+          canonical_id?: string
+          confidence?: number
+          created_at?: string
+          id?: string
+          needs_review?: boolean
+          normalized_alias?: string
+          source?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_aliases_canonical_fk"
+            columns: ["canonical_id", "user_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_canonical"
+            referencedColumns: ["id", "user_id"]
+          },
+        ]
+      }
+      exercise_canonical: {
+        Row: {
+          created_at: string
+          display_name: string
+          id: string
+          normalized_name: string
+          updated_at: string
+          usage_count: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          id?: string
+          normalized_name: string
+          updated_at?: string
+          usage_count?: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          id?: string
+          normalized_name?: string
+          updated_at?: string
+          usage_count?: number
+          user_id?: string
+        }
+        Relationships: []
+      }
+      exercise_execution_submissions: {
+        Row: {
+          created_at: string
+          exercise_id: string | null
+          exercise_library_id: string | null
+          exercise_name: string | null
+          id: string
+          notes: string | null
+          reviewed_at: string | null
+          reviewed_by: string | null
+          status: Database["public"]["Enums"]["exercise_execution_submission_status"]
+          student_user_id: string
+          teacher_feedback: string | null
+          updated_at: string
+          video_bucket_id: string
+          video_object_path: string | null
+          workout_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          exercise_id?: string | null
+          exercise_library_id?: string | null
+          exercise_name?: string | null
+          id?: string
+          notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: Database["public"]["Enums"]["exercise_execution_submission_status"]
+          student_user_id: string
+          teacher_feedback?: string | null
+          updated_at?: string
+          video_bucket_id?: string
+          video_object_path?: string | null
+          workout_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          exercise_id?: string | null
+          exercise_library_id?: string | null
+          exercise_name?: string | null
+          id?: string
+          notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          status?: Database["public"]["Enums"]["exercise_execution_submission_status"]
+          student_user_id?: string
+          teacher_feedback?: string | null
+          updated_at?: string
+          video_bucket_id?: string
+          video_object_path?: string | null
+          workout_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_execution_submissions_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "exercise_execution_submissions_exercise_library_id_fkey"
+            columns: ["exercise_library_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_library"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "exercise_execution_submissions_workout_id_fkey"
+            columns: ["workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      exercise_library: {
+        Row: {
+          aliases: string[] | null
+          created_at: string
+          difficulty: string | null
+          display_name_pt: string
+          environments: string[]
+          equipment: string[]
+          id: string
+          is_compound: boolean
+          normalized_name: string
+          primary_muscle: string | null
+          secondary_muscles: string[]
+          video_url: string | null
+        }
+        Insert: {
+          aliases?: string[] | null
+          created_at?: string
+          difficulty?: string | null
+          display_name_pt: string
+          environments?: string[]
+          equipment?: string[]
+          id?: string
+          is_compound?: boolean
+          normalized_name: string
+          primary_muscle?: string | null
+          secondary_muscles?: string[]
+          video_url?: string | null
+        }
+        Update: {
+          aliases?: string[] | null
+          created_at?: string
+          difficulty?: string | null
+          display_name_pt?: string
+          environments?: string[]
+          equipment?: string[]
+          id?: string
+          is_compound?: boolean
+          normalized_name?: string
+          primary_muscle?: string | null
+          secondary_muscles?: string[]
+          video_url?: string | null
+        }
+        Relationships: []
+      }
+      exercise_muscle_maps: {
+        Row: {
+          canonical_name: string | null
+          confidence: number
+          exercise_key: string
+          mapping: Json
+          source: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          canonical_name?: string | null
+          confidence?: number
+          exercise_key: string
+          mapping: Json
+          source?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Update: {
+          canonical_name?: string | null
+          confidence?: number
+          exercise_key?: string
+          mapping?: Json
+          source?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      exercise_videos: {
+        Row: {
+          approved_at: string | null
+          channel_title: string | null
+          created_at: string
+          created_by: string | null
+          exercise_library_id: string
+          id: string
+          is_primary: boolean
+          language: string | null
+          normalized_name: string
+          provider: string
+          provider_video_id: string
+          status: string
+          title: string | null
+          url: string
+        }
+        Insert: {
+          approved_at?: string | null
+          channel_title?: string | null
+          created_at?: string
+          created_by?: string | null
+          exercise_library_id: string
+          id?: string
+          is_primary?: boolean
+          language?: string | null
+          normalized_name: string
+          provider?: string
+          provider_video_id?: string
+          status?: string
+          title?: string | null
+          url: string
+        }
+        Update: {
+          approved_at?: string | null
+          channel_title?: string | null
+          created_at?: string
+          created_by?: string | null
+          exercise_library_id?: string
+          id?: string
+          is_primary?: boolean
+          language?: string | null
+          normalized_name?: string
+          provider?: string
+          provider_video_id?: string
+          status?: string
+          title?: string | null
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercise_videos_exercise_library_id_fkey"
+            columns: ["exercise_library_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_library"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      exercises: {
+        Row: {
+          cadence: string | null
+          id: string
+          is_unilateral: boolean
+          method: string | null
+          muscle_group: string | null
+          name: string
+          notes: string | null
+          order: number | null
+          rest_time: number | null
+          side_rest_time: number | null
+          transition_time: number | null
+          video_url: string | null
+          workout_id: string | null
+        }
+        Insert: {
+          cadence?: string | null
+          id?: string
+          is_unilateral?: boolean
+          method?: string | null
+          muscle_group?: string | null
+          name: string
+          notes?: string | null
+          order?: number | null
+          rest_time?: number | null
+          side_rest_time?: number | null
+          transition_time?: number | null
+          video_url?: string | null
+          workout_id?: string | null
+        }
+        Update: {
+          cadence?: string | null
+          id?: string
+          is_unilateral?: boolean
+          method?: string | null
+          muscle_group?: string | null
+          name?: string
+          notes?: string | null
+          order?: number | null
+          rest_time?: number | null
+          side_rest_time?: number | null
+          transition_time?: number | null
+          video_url?: string | null
+          workout_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "exercises_workout_id_fkey"
+            columns: ["workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feature_flags: {
+        Row: {
+          description: string | null
+          enabled: boolean
+          key: string
+          metadata: Json | null
+          owner: string | null
+          review_at: string | null
+          updated_at: string | null
+          updated_by: string | null
+        }
+        Insert: {
+          description?: string | null
+          enabled?: boolean
+          key: string
+          metadata?: Json | null
+          owner?: string | null
+          review_at?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
+        Update: {
+          description?: string | null
+          enabled?: boolean
+          key?: string
+          metadata?: Json | null
+          owner?: string | null
+          review_at?: string | null
+          updated_at?: string | null
+          updated_by?: string | null
+        }
+        Relationships: []
+      }
+      gym_checkins: {
+        Row: {
+          checked_in_at: string | null
+          gym_id: string | null
+          id: string
+          latitude: number | null
+          longitude: number | null
+          user_id: string
+          workout_id: string | null
+        }
+        Insert: {
+          checked_in_at?: string | null
+          gym_id?: string | null
+          id?: string
+          latitude?: number | null
+          longitude?: number | null
+          user_id: string
+          workout_id?: string | null
+        }
+        Update: {
+          checked_in_at?: string | null
+          gym_id?: string | null
+          id?: string
+          latitude?: number | null
+          longitude?: number | null
+          user_id?: string
+          workout_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gym_checkins_gym_id_fkey"
+            columns: ["gym_id"]
+            isOneToOne: false
+            referencedRelation: "user_gyms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      invites: {
+        Row: {
+          created_at: string | null
+          from_uid: string | null
+          id: string
+          status: string | null
+          team_session_id: string | null
+          to_uid: string | null
+          workout_data: Json | null
+        }
+        Insert: {
+          created_at?: string | null
+          from_uid?: string | null
+          id?: string
+          status?: string | null
+          team_session_id?: string | null
+          to_uid?: string | null
+          workout_data?: Json | null
+        }
+        Update: {
+          created_at?: string | null
+          from_uid?: string | null
+          id?: string
+          status?: string | null
+          team_session_id?: string | null
+          to_uid?: string | null
+          workout_data?: Json | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "invites_from_uid_fkey"
+            columns: ["from_uid"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "invites_to_uid_fkey"
+            columns: ["to_uid"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lab_result_markers: {
+        Row: {
+          category: string
+          created_at: string
+          id: string
+          lab_result_id: string
+          marker_name: string
+          ref_max: number | null
+          ref_min: number | null
+          status: string | null
+          unit: string
+          value: number
+        }
+        Insert: {
+          category?: string
+          created_at?: string
+          id?: string
+          lab_result_id: string
+          marker_name: string
+          ref_max?: number | null
+          ref_min?: number | null
+          status?: string | null
+          unit: string
+          value: number
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          id?: string
+          lab_result_id?: string
+          marker_name?: string
+          ref_max?: number | null
+          ref_min?: number | null
+          status?: string | null
+          unit?: string
+          value?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lab_result_markers_lab_result_id_fkey"
+            columns: ["lab_result_id"]
+            isOneToOne: false
+            referencedRelation: "lab_results"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lab_results: {
+        Row: {
+          created_at: string
+          doctor_name: string | null
+          exam_date: string
+          id: string
+          lab_name: string | null
+          observations: string | null
+          pdf_url: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          doctor_name?: string | null
+          exam_date: string
+          id?: string
+          lab_name?: string | null
+          observations?: string | null
+          pdf_url?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          doctor_name?: string | null
+          exam_date?: string
+          id?: string
+          lab_name?: string | null
+          observations?: string | null
+          pdf_url?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      marketplace_payments: {
+        Row: {
+          amount_cents: number
+          asaas_payment_id: string | null
+          billing_type: string | null
+          created_at: string
+          due_date: string | null
+          id: string
+          invoice_url: string | null
+          paid_at: string | null
+          pix_payload: string | null
+          pix_qr_code: string | null
+          plan_id: string | null
+          platform_fee_cents: number
+          status: string
+          student_user_id: string
+          subscription_id: string | null
+          teacher_user_id: string
+        }
+        Insert: {
+          amount_cents: number
+          asaas_payment_id?: string | null
+          billing_type?: string | null
+          created_at?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          platform_fee_cents?: number
+          status?: string
+          student_user_id: string
+          subscription_id?: string | null
+          teacher_user_id: string
+        }
+        Update: {
+          amount_cents?: number
+          asaas_payment_id?: string | null
+          billing_type?: string | null
+          created_at?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          platform_fee_cents?: number
+          status?: string
+          student_user_id?: string
+          subscription_id?: string | null
+          teacher_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketplace_payments_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "teacher_plans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "marketplace_payments_subscription_id_fkey"
+            columns: ["subscription_id"]
+            isOneToOne: false
+            referencedRelation: "marketplace_subscriptions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      marketplace_subscriptions: {
+        Row: {
+          asaas_customer_id: string | null
+          asaas_subscription_id: string | null
+          created_at: string
+          id: string
+          plan_id: string
+          status: string
+          student_user_id: string
+          teacher_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          asaas_customer_id?: string | null
+          asaas_subscription_id?: string | null
+          created_at?: string
+          id?: string
+          plan_id: string
+          status?: string
+          student_user_id: string
+          teacher_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          asaas_customer_id?: string | null
+          asaas_subscription_id?: string | null
+          created_at?: string
+          id?: string
+          plan_id?: string
+          status?: string
+          student_user_id?: string
+          teacher_user_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketplace_subscriptions_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "teacher_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      mercadopago_webhook_events: {
+        Row: {
+          action: string | null
+          created_at: string
+          data_id: string
+          event_type: string | null
+          id: string
+          payload: Json
+          request_id: string
+        }
+        Insert: {
+          action?: string | null
+          created_at?: string
+          data_id: string
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          request_id: string
+        }
+        Update: {
+          action?: string | null
+          created_at?: string
+          data_id?: string
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          request_id?: string
+        }
+        Relationships: []
+      }
+      muscle_weekly_summaries: {
+        Row: {
+          payload: Json
+          updated_at: string
+          user_id: string
+          week_start_date: string
+        }
+        Insert: {
+          payload: Json
+          updated_at?: string
+          user_id?: string
+          week_start_date: string
+        }
+        Update: {
+          payload?: Json
+          updated_at?: string
+          user_id?: string
+          week_start_date?: string
+        }
+        Relationships: []
+      }
+      notifications: {
+        Row: {
+          created_at: string
+          id: string
+          is_read: boolean
+          message: string
+          metadata: Json
+          read: boolean | null
+          recipient_id: string
+          sender_id: string | null
+          title: string
+          type: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          message: string
+          metadata?: Json
+          read?: boolean | null
+          recipient_id: string
+          sender_id?: string | null
+          title: string
+          type?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_read?: boolean
+          message?: string
+          metadata?: Json
+          read?: boolean | null
+          recipient_id?: string
+          sender_id?: string | null
+          title?: string
+          type?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      nutrition_custom_foods: {
+        Row: {
+          aliases: string[]
+          carbs_per100g: number
+          created_at: string
+          fat_per100g: number
+          fiber_per100g: number
+          id: string
+          kcal_per100g: number
+          label_image_url: string | null
+          name: string
+          protein_per100g: number
+          serving_size_g: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          aliases?: string[]
+          carbs_per100g?: number
+          created_at?: string
+          fat_per100g?: number
+          fiber_per100g?: number
+          id?: string
+          kcal_per100g?: number
+          label_image_url?: string | null
+          name: string
+          protein_per100g?: number
+          serving_size_g?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          aliases?: string[]
+          carbs_per100g?: number
+          created_at?: string
+          fat_per100g?: number
+          fiber_per100g?: number
+          id?: string
+          kcal_per100g?: number
+          label_image_url?: string | null
+          name?: string
+          protein_per100g?: number
+          serving_size_g?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      nutrition_favorite_meals: {
+        Row: {
+          created_at: string
+          id: string
+          meal_text: string
+          name: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          meal_text: string
+          name: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          meal_text?: string
+          name?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      nutrition_goals: {
+        Row: {
+          calories: number
+          carbs: number
+          created_at: string
+          fat: number
+          id: string
+          protein: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          fat?: number
+          id?: string
+          protein?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          fat?: number
+          id?: string
+          protein?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      nutrition_learned_foods: {
+        Row: {
+          carbs_per_100g: number
+          created_at: string | null
+          display_name: string
+          fat_per_100g: number
+          food_key: string
+          id: string
+          kcal_per_100g: number
+          protein_per_100g: number
+          source: string | null
+          updated_at: string | null
+          use_count: number | null
+          user_id: string
+        }
+        Insert: {
+          carbs_per_100g: number
+          created_at?: string | null
+          display_name: string
+          fat_per_100g: number
+          food_key: string
+          id?: string
+          kcal_per_100g: number
+          protein_per_100g: number
+          source?: string | null
+          updated_at?: string | null
+          use_count?: number | null
+          user_id: string
+        }
+        Update: {
+          carbs_per_100g?: number
+          created_at?: string | null
+          display_name?: string
+          fat_per_100g?: number
+          food_key?: string
+          id?: string
+          kcal_per_100g?: number
+          protein_per_100g?: number
+          source?: string | null
+          updated_at?: string | null
+          use_count?: number | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      nutrition_meal_entries: {
+        Row: {
+          calories: number
+          carbs: number
+          created_at: string
+          date: string
+          fat: number
+          food_name: string
+          id: string
+          protein: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          date: string
+          fat?: number
+          food_name: string
+          id?: string
+          protein?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          calories?: number
+          carbs?: number
+          created_at?: string
+          date?: string
+          fat?: number
+          food_name?: string
+          id?: string
+          protein?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      onboarding_events: {
+        Row: {
+          created_at: string
+          event: string
+          id: number
+          payload: Json
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event: string
+          id?: number
+          payload?: Json
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event?: string
+          id?: number
+          payload?: Json
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "onboarding_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      password_recovery_codes: {
+        Row: {
+          code_hash: string
+          created_at: string
+          id: string
+          last4: string | null
+          used_at: string | null
+          user_id: string
+        }
+        Insert: {
+          code_hash: string
+          created_at?: string
+          id?: string
+          last4?: string | null
+          used_at?: string | null
+          user_id: string
+        }
+        Update: {
+          code_hash?: string
+          created_at?: string
+          id?: string
+          last4?: string | null
+          used_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      photos: {
+        Row: {
+          created_at: string | null
+          date: string | null
+          id: string
+          kind: string
+          notes: string | null
+          url: string
+          user_id: string | null
+          weight_kg: number | null
+        }
+        Insert: {
+          created_at?: string | null
+          date?: string | null
+          id?: string
+          kind?: string
+          notes?: string | null
+          url: string
+          user_id?: string | null
+          weight_kg?: number | null
+        }
+        Update: {
+          created_at?: string | null
+          date?: string | null
+          id?: string
+          kind?: string
+          notes?: string | null
+          url?: string
+          user_id?: string | null
+          weight_kg?: number | null
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          approval_status: string | null
+          approved_at: string | null
+          approved_by: string | null
+          display_name: string | null
+          email: string | null
+          id: string
+          is_approved: boolean | null
+          last_seen: string | null
+          photo_url: string | null
+          referral_code: string | null
+          role: string | null
+        }
+        Insert: {
+          approval_status?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          display_name?: string | null
+          email?: string | null
+          id: string
+          is_approved?: boolean | null
+          last_seen?: string | null
+          photo_url?: string | null
+          referral_code?: string | null
+          role?: string | null
+        }
+        Update: {
+          approval_status?: string | null
+          approved_at?: string | null
+          approved_by?: string | null
+          display_name?: string | null
+          email?: string | null
+          id?: string
+          is_approved?: boolean | null
+          last_seen?: string | null
+          photo_url?: string | null
+          referral_code?: string | null
+          role?: string | null
+        }
+        Relationships: []
+      }
+      referrals: {
+        Row: {
+          created_at: string
+          id: string
+          referred_id: string
+          referrer_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          referred_id: string
+          referrer_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          referred_id?: string
+          referrer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "referrals_referred_id_fkey"
+            columns: ["referred_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "referrals_referrer_id_fkey"
+            columns: ["referrer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sessions: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          tracks_config: Json | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          tracks_config?: Json | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          tracks_config?: Json | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sessions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sets: {
+        Row: {
+          advanced_config: Json | null
+          completed: boolean | null
+          duration_seconds: number | null
+          exercise_id: string | null
+          id: string
+          is_warmup: boolean
+          reps: string | null
+          rpe: number | null
+          set_number: number | null
+          weight: number | null
+        }
+        Insert: {
+          advanced_config?: Json | null
+          completed?: boolean | null
+          duration_seconds?: number | null
+          exercise_id?: string | null
+          id?: string
+          is_warmup?: boolean
+          reps?: string | null
+          rpe?: number | null
+          set_number?: number | null
+          weight?: number | null
+        }
+        Update: {
+          advanced_config?: Json | null
+          completed?: boolean | null
+          duration_seconds?: number | null
+          exercise_id?: string | null
+          id?: string
+          is_warmup?: boolean
+          reps?: string | null
+          rpe?: number | null
+          set_number?: number | null
+          weight?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sets_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_follows: {
+        Row: {
+          created_at: string
+          follower_id: string
+          following_id: string
+          status: Database["public"]["Enums"]["social_follow_status"]
+        }
+        Insert: {
+          created_at?: string
+          follower_id: string
+          following_id: string
+          status?: Database["public"]["Enums"]["social_follow_status"]
+        }
+        Update: {
+          created_at?: string
+          follower_id?: string
+          following_id?: string
+          status?: Database["public"]["Enums"]["social_follow_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_follows_follower_id_fkey"
+            columns: ["follower_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_follows_following_id_fkey"
+            columns: ["following_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_stories: {
+        Row: {
+          author_id: string
+          caption: string | null
+          created_at: string
+          expires_at: string
+          id: string
+          is_deleted: boolean
+          media_path: string
+          meta: Json
+        }
+        Insert: {
+          author_id: string
+          caption?: string | null
+          created_at?: string
+          expires_at?: string
+          id?: string
+          is_deleted?: boolean
+          media_path: string
+          meta?: Json
+        }
+        Update: {
+          author_id?: string
+          caption?: string | null
+          created_at?: string
+          expires_at?: string
+          id?: string
+          is_deleted?: boolean
+          media_path?: string
+          meta?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_stories_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_story_comments: {
+        Row: {
+          body: string
+          created_at: string
+          id: number
+          story_id: string
+          user_id: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          id?: number
+          story_id: string
+          user_id: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          id?: number
+          story_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_story_comments_story_id_fkey"
+            columns: ["story_id"]
+            isOneToOne: false
+            referencedRelation: "social_stories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_story_comments_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_story_likes: {
+        Row: {
+          created_at: string
+          story_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          story_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          story_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_story_likes_story_id_fkey"
+            columns: ["story_id"]
+            isOneToOne: false
+            referencedRelation: "social_stories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_story_likes_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      social_story_views: {
+        Row: {
+          story_id: string
+          viewed_at: string
+          viewer_id: string
+        }
+        Insert: {
+          story_id: string
+          viewed_at?: string
+          viewer_id: string
+        }
+        Update: {
+          story_id?: string
+          viewed_at?: string
+          viewer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_story_views_story_id_fkey"
+            columns: ["story_id"]
+            isOneToOne: false
+            referencedRelation: "social_stories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_story_views_viewer_id_fkey"
+            columns: ["viewer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      soft_delete_bin: {
+        Row: {
+          created_at: string
+          delete_reason: string | null
+          deleted_at: string
+          deleted_by: string | null
+          entity_id: string | null
+          entity_type: string
+          id: string
+          media_paths: string[]
+          payload: Json
+          purge_after: string
+          purged_at: string | null
+        }
+        Insert: {
+          created_at?: string
+          delete_reason?: string | null
+          deleted_at?: string
+          deleted_by?: string | null
+          entity_id?: string | null
+          entity_type: string
+          id?: string
+          media_paths?: string[]
+          payload?: Json
+          purge_after?: string
+          purged_at?: string | null
+        }
+        Update: {
+          created_at?: string
+          delete_reason?: string | null
+          deleted_at?: string
+          deleted_by?: string | null
+          entity_id?: string | null
+          entity_type?: string
+          id?: string
+          media_paths?: string[]
+          payload?: Json
+          purge_after?: string
+          purged_at?: string | null
+        }
+        Relationships: []
+      }
+      student_charges: {
+        Row: {
+          amount_cents: number
+          created_at: string
+          currency: string
+          due_date: string | null
+          id: string
+          invoice_url: string | null
+          paid_at: string | null
+          pix_payload: string | null
+          pix_qr_code: string | null
+          plan_id: string | null
+          provider: string
+          provider_payment_id: string | null
+          raw: Json | null
+          status: string
+          student_user_id: string
+          subscription_id: string | null
+          teacher_user_id: string
+        }
+        Insert: {
+          amount_cents: number
+          created_at?: string
+          currency?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          provider?: string
+          provider_payment_id?: string | null
+          raw?: Json | null
+          status?: string
+          student_user_id: string
+          subscription_id?: string | null
+          teacher_user_id: string
+        }
+        Update: {
+          amount_cents?: number
+          created_at?: string
+          currency?: string
+          due_date?: string | null
+          id?: string
+          invoice_url?: string | null
+          paid_at?: string | null
+          pix_payload?: string | null
+          pix_qr_code?: string | null
+          plan_id?: string | null
+          provider?: string
+          provider_payment_id?: string | null
+          raw?: Json | null
+          status?: string
+          student_user_id?: string
+          subscription_id?: string | null
+          teacher_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_charges_subscription_id_fkey"
+            columns: ["subscription_id"]
+            isOneToOne: false
+            referencedRelation: "student_subscriptions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      student_service_plans: {
+        Row: {
+          billing_interval: string
+          created_at: string
+          currency: string
+          description: string | null
+          duration_days: number
+          id: string
+          is_active: boolean
+          name: string
+          notes: string | null
+          price_cents: number
+          session_duration_minutes: number | null
+          sessions_per_week: number | null
+          teacher_user_id: string
+          training_days: string[] | null
+          updated_at: string
+        }
+        Insert: {
+          billing_interval?: string
+          created_at?: string
+          currency?: string
+          description?: string | null
+          duration_days?: number
+          id?: string
+          is_active?: boolean
+          name: string
+          notes?: string | null
+          price_cents?: number
+          session_duration_minutes?: number | null
+          sessions_per_week?: number | null
+          teacher_user_id: string
+          training_days?: string[] | null
+          updated_at?: string
+        }
+        Update: {
+          billing_interval?: string
+          created_at?: string
+          currency?: string
+          description?: string | null
+          duration_days?: number
+          id?: string
+          is_active?: boolean
+          name?: string
+          notes?: string | null
+          price_cents?: number
+          session_duration_minutes?: number | null
+          sessions_per_week?: number | null
+          teacher_user_id?: string
+          training_days?: string[] | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      student_subscriptions: {
+        Row: {
+          created_at: string
+          expires_at: string | null
+          id: string
+          last_payment_at: string | null
+          next_due_date: string | null
+          plan_id: string
+          provider: string
+          provider_subscription_id: string | null
+          started_at: string | null
+          status: string
+          student_user_id: string
+          teacher_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          last_payment_at?: string | null
+          next_due_date?: string | null
+          plan_id: string
+          provider?: string
+          provider_subscription_id?: string | null
+          started_at?: string | null
+          status?: string
+          student_user_id: string
+          teacher_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          last_payment_at?: string | null
+          next_due_date?: string | null
+          plan_id?: string
+          provider?: string
+          provider_subscription_id?: string | null
+          started_at?: string | null
+          status?: string
+          student_user_id?: string
+          teacher_user_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_subscriptions_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "student_service_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      students: {
+        Row: {
+          created_at: string | null
+          email: string | null
+          id: string
+          name: string
+          status: string | null
+          teacher_id: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          name: string
+          status?: string | null
+          teacher_id?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          name?: string
+          status?: string | null
+          teacher_id?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      teacher_plans: {
+        Row: {
+          created_at: string
+          currency: string
+          description: string | null
+          id: string
+          interval: string
+          name: string
+          price_cents: number
+          status: string
+          teacher_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: string
+          interval?: string
+          name: string
+          price_cents: number
+          status?: string
+          teacher_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: string
+          interval?: string
+          name?: string
+          price_cents?: number
+          status?: string
+          teacher_user_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      teacher_tiers: {
+        Row: {
+          created_at: string
+          currency: string
+          description: string | null
+          is_active: boolean
+          max_students: number
+          name: string
+          price_cents: number
+          sort_order: number
+          tier_key: string
+        }
+        Insert: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          is_active?: boolean
+          max_students?: number
+          name: string
+          price_cents?: number
+          sort_order?: number
+          tier_key: string
+        }
+        Update: {
+          created_at?: string
+          currency?: string
+          description?: string | null
+          is_active?: boolean
+          max_students?: number
+          name?: string
+          price_cents?: number
+          sort_order?: number
+          tier_key?: string
+        }
+        Relationships: []
+      }
+      teachers: {
+        Row: {
+          asaas_account_id: string | null
+          asaas_account_status: string | null
+          asaas_wallet_id: string | null
+          birth_date: string | null
+          created_at: string
+          email: string
+          id: string
+          name: string
+          payment_status: string
+          phone: string | null
+          plan_status: string
+          plan_subscription_id: string | null
+          plan_tier_key: string
+          plan_valid_until: string | null
+          status: string
+          user_id: string | null
+        }
+        Insert: {
+          asaas_account_id?: string | null
+          asaas_account_status?: string | null
+          asaas_wallet_id?: string | null
+          birth_date?: string | null
+          created_at?: string
+          email: string
+          id?: string
+          name: string
+          payment_status?: string
+          phone?: string | null
+          plan_status?: string
+          plan_subscription_id?: string | null
+          plan_tier_key?: string
+          plan_valid_until?: string | null
+          status?: string
+          user_id?: string | null
+        }
+        Update: {
+          asaas_account_id?: string | null
+          asaas_account_status?: string | null
+          asaas_wallet_id?: string | null
+          birth_date?: string | null
+          created_at?: string
+          email?: string
+          id?: string
+          name?: string
+          payment_status?: string
+          phone?: string | null
+          plan_status?: string
+          plan_subscription_id?: string | null
+          plan_tier_key?: string
+          plan_valid_until?: string | null
+          status?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "teachers_plan_tier_key_fkey"
+            columns: ["plan_tier_key"]
+            isOneToOne: false
+            referencedRelation: "teacher_tiers"
+            referencedColumns: ["tier_key"]
+          },
+        ]
+      }
+      team_chat_messages: {
+        Row: {
+          content: string
+          created_at: string
+          display_name: string
+          id: string
+          photo_url: string | null
+          session_id: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          display_name?: string
+          id?: string
+          photo_url?: string | null
+          session_id: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          display_name?: string
+          id?: string
+          photo_url?: string | null
+          session_id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      team_session_presence: {
+        Row: {
+          session_id: string
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          session_id: string
+          status: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          session_id?: string
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "team_session_presence_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "team_sessions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      team_sessions: {
+        Row: {
+          created_at: string | null
+          host_uid: string | null
+          id: string
+          participants: Json | null
+          status: string | null
+          updated_at: string
+          workout_state: Json | null
+        }
+        Insert: {
+          created_at?: string | null
+          host_uid?: string | null
+          id?: string
+          participants?: Json | null
+          status?: string | null
+          updated_at?: string
+          workout_state?: Json | null
+        }
+        Update: {
+          created_at?: string | null
+          host_uid?: string | null
+          id?: string
+          participants?: Json | null
+          status?: string | null
+          updated_at?: string
+          workout_state?: Json | null
+        }
+        Relationships: []
+      }
+      tracks: {
+        Row: {
+          bpm: number | null
+          created_at: string | null
+          duration: number | null
+          filename: string
+          id: string
+          key: string | null
+          metadata: Json | null
+          original_name: string
+          storage_path: string
+          user_id: string | null
+        }
+        Insert: {
+          bpm?: number | null
+          created_at?: string | null
+          duration?: number | null
+          filename: string
+          id?: string
+          key?: string | null
+          metadata?: Json | null
+          original_name: string
+          storage_path: string
+          user_id?: string | null
+        }
+        Update: {
+          bpm?: number | null
+          created_at?: string | null
+          duration?: number | null
+          filename?: string
+          id?: string
+          key?: string | null
+          metadata?: Json | null
+          original_name?: string
+          storage_path?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tracks_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      update_notifications: {
+        Row: {
+          created_at: string
+          description: string
+          id: string
+          is_active: boolean
+          release_date: string
+          title: string
+          version: string
+        }
+        Insert: {
+          created_at?: string
+          description: string
+          id?: string
+          is_active?: boolean
+          release_date?: string
+          title: string
+          version: string
+        }
+        Update: {
+          created_at?: string
+          description?: string
+          id?: string
+          is_active?: boolean
+          release_date?: string
+          title?: string
+          version?: string
+        }
+        Relationships: []
+      }
+      user_activity_events: {
+        Row: {
+          app_version: string | null
+          client_ts: string | null
+          created_at: string
+          display_name: string | null
+          event_name: string
+          event_type: string | null
+          id: string
+          metadata: Json
+          path: string | null
+          role: string | null
+          screen: string | null
+          user_agent: string | null
+          user_id: string
+        }
+        Insert: {
+          app_version?: string | null
+          client_ts?: string | null
+          created_at?: string
+          display_name?: string | null
+          event_name: string
+          event_type?: string | null
+          id?: string
+          metadata?: Json
+          path?: string | null
+          role?: string | null
+          screen?: string | null
+          user_agent?: string | null
+          user_id: string
+        }
+        Update: {
+          app_version?: string | null
+          client_ts?: string | null
+          created_at?: string
+          display_name?: string | null
+          event_name?: string
+          event_type?: string | null
+          id?: string
+          metadata?: Json
+          path?: string | null
+          role?: string | null
+          screen?: string | null
+          user_agent?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_entitlements: {
+        Row: {
+          created_at: string
+          current_period_end: string | null
+          current_period_start: string | null
+          id: string
+          limits_override: Json
+          metadata: Json
+          plan_id: string | null
+          provider: string
+          provider_customer_id: string | null
+          provider_subscription_id: string | null
+          status: string
+          updated_at: string
+          user_id: string
+          valid_from: string
+          valid_until: string | null
+        }
+        Insert: {
+          created_at?: string
+          current_period_end?: string | null
+          current_period_start?: string | null
+          id?: string
+          limits_override?: Json
+          metadata?: Json
+          plan_id?: string | null
+          provider?: string
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
+          status?: string
+          updated_at?: string
+          user_id: string
+          valid_from?: string
+          valid_until?: string | null
+        }
+        Update: {
+          created_at?: string
+          current_period_end?: string | null
+          current_period_start?: string | null
+          id?: string
+          limits_override?: Json
+          metadata?: Json
+          plan_id?: string | null
+          provider?: string
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
+          status?: string
+          updated_at?: string
+          user_id?: string
+          valid_from?: string
+          valid_until?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_entitlements_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "app_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_gyms: {
+        Row: {
+          created_at: string | null
+          id: string
+          is_primary: boolean | null
+          latitude: number
+          longitude: number
+          name: string
+          qr_token: string
+          radius_meters: number | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          is_primary?: boolean | null
+          latitude: number
+          longitude: number
+          name: string
+          qr_token?: string
+          radius_meters?: number | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          is_primary?: boolean | null
+          latitude?: number
+          longitude?: number
+          name?: string
+          qr_token?: string
+          radius_meters?: number | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_location_settings: {
+        Row: {
+          auto_checkin: boolean | null
+          gps_enabled: boolean | null
+          share_gym_presence: boolean | null
+          show_on_gym_leaderboard: boolean | null
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          auto_checkin?: boolean | null
+          gps_enabled?: boolean | null
+          share_gym_presence?: boolean | null
+          show_on_gym_leaderboard?: boolean | null
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          auto_checkin?: boolean | null
+          gps_enabled?: boolean | null
+          share_gym_presence?: boolean | null
+          show_on_gym_leaderboard?: boolean | null
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_settings: {
+        Row: {
+          created_at: string
+          preferences: Json
+          tour_completed_at: string | null
+          tour_skipped_at: string | null
+          tour_version: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          preferences?: Json
+          tour_completed_at?: string | null
+          tour_skipped_at?: string | null
+          tour_version?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          preferences?: Json
+          tour_completed_at?: string | null
+          tour_skipped_at?: string | null
+          tour_version?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_settings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_update_views: {
+        Row: {
+          created_at: string
+          id: string
+          prompted_at: string | null
+          update_id: string
+          user_id: string
+          viewed_at: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          prompted_at?: string | null
+          update_id: string
+          user_id: string
+          viewed_at?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          prompted_at?: string | null
+          update_id?: string
+          user_id?: string
+          viewed_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_update_views_update_id_fkey"
+            columns: ["update_id"]
+            isOneToOne: false
+            referencedRelation: "update_notifications"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          avatar_url: string | null
+          created_at: string | null
+          email: string
+          id: string
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          avatar_url?: string | null
+          created_at?: string | null
+          email: string
+          id?: string
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          avatar_url?: string | null
+          created_at?: string | null
+          email?: string
+          id?: string
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      vip_chat_messages: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          role: string
+          thread_id: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          role: string
+          thread_id: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          role?: string
+          thread_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vip_chat_messages_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "vip_chat_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vip_chat_threads: {
+        Row: {
+          created_at: string
+          id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      vip_periodization_exercise_state: {
+        Row: {
+          estimated_1rm: number | null
+          id: string
+          last_reps: number | null
+          last_weight: number | null
+          normalized_exercise_name: string
+          program_id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          estimated_1rm?: number | null
+          id?: string
+          last_reps?: number | null
+          last_weight?: number | null
+          normalized_exercise_name: string
+          program_id: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          estimated_1rm?: number | null
+          id?: string
+          last_reps?: number | null
+          last_weight?: number | null
+          normalized_exercise_name?: string
+          program_id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vip_periodization_exercise_state_program_id_fkey"
+            columns: ["program_id"]
+            isOneToOne: false
+            referencedRelation: "vip_periodization_programs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vip_periodization_programs: {
+        Row: {
+          config: Json
+          created_at: string
+          days_per_week: number
+          equipment: string[]
+          goal: string
+          id: string
+          limitations: string | null
+          model: string
+          questionnaire: Json
+          split: string
+          start_date: string | null
+          status: string
+          time_minutes: number
+          updated_at: string
+          user_id: string
+          weeks: number
+        }
+        Insert: {
+          config?: Json
+          created_at?: string
+          days_per_week: number
+          equipment?: string[]
+          goal?: string
+          id?: string
+          limitations?: string | null
+          model: string
+          questionnaire?: Json
+          split: string
+          start_date?: string | null
+          status?: string
+          time_minutes: number
+          updated_at?: string
+          user_id: string
+          weeks: number
+        }
+        Update: {
+          config?: Json
+          created_at?: string
+          days_per_week?: number
+          equipment?: string[]
+          goal?: string
+          id?: string
+          limitations?: string | null
+          model?: string
+          questionnaire?: Json
+          split?: string
+          start_date?: string | null
+          status?: string
+          time_minutes?: number
+          updated_at?: string
+          user_id?: string
+          weeks?: number
+        }
+        Relationships: []
+      }
+      vip_periodization_workouts: {
+        Row: {
+          created_at: string
+          day_number: number
+          id: string
+          is_deload: boolean
+          is_test: boolean
+          phase: string
+          program_id: string
+          scheduled_date: string | null
+          user_id: string
+          week_number: number
+          workout_id: string
+        }
+        Insert: {
+          created_at?: string
+          day_number: number
+          id?: string
+          is_deload?: boolean
+          is_test?: boolean
+          phase: string
+          program_id: string
+          scheduled_date?: string | null
+          user_id: string
+          week_number: number
+          workout_id: string
+        }
+        Update: {
+          created_at?: string
+          day_number?: number
+          id?: string
+          is_deload?: boolean
+          is_test?: boolean
+          phase?: string
+          program_id?: string
+          scheduled_date?: string | null
+          user_id?: string
+          week_number?: number
+          workout_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vip_periodization_workouts_program_id_fkey"
+            columns: ["program_id"]
+            isOneToOne: false
+            referencedRelation: "vip_periodization_programs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vip_periodization_workouts_workout_id_fkey"
+            columns: ["workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vip_profile: {
+        Row: {
+          constraints: string | null
+          equipment: string | null
+          goal: string | null
+          preferences: Json
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          constraints?: string | null
+          equipment?: string | null
+          goal?: string | null
+          preferences?: Json
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          constraints?: string | null
+          equipment?: string | null
+          goal?: string | null
+          preferences?: Json
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      vip_usage_daily: {
+        Row: {
+          day: string
+          feature_key: string
+          last_used_at: string | null
+          updated_at: string
+          usage_count: number
+          user_id: string
+        }
+        Insert: {
+          day?: string
+          feature_key: string
+          last_used_at?: string | null
+          updated_at?: string
+          usage_count?: number
+          user_id: string
+        }
+        Update: {
+          day?: string
+          feature_key?: string
+          last_used_at?: string | null
+          updated_at?: string
+          usage_count?: number
+          user_id?: string
+        }
+        Relationships: []
+      }
+      vip_welcome_views: {
+        Row: {
+          first_seen_at: string
+          last_seen_at: string
+          user_id: string
+        }
+        Insert: {
+          first_seen_at?: string
+          last_seen_at?: string
+          user_id: string
+        }
+        Update: {
+          first_seen_at?: string
+          last_seen_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      webhook_dead_letters: {
+        Row: {
+          attempts: number | null
+          created_at: string | null
+          error_message: string | null
+          event_type: string | null
+          id: string
+          payload: Json
+          resolved_at: string | null
+          source: string
+        }
+        Insert: {
+          attempts?: number | null
+          created_at?: string | null
+          error_message?: string | null
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          resolved_at?: string | null
+          source: string
+        }
+        Update: {
+          attempts?: number | null
+          created_at?: string | null
+          error_message?: string | null
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          resolved_at?: string | null
+          source?: string
+        }
+        Relationships: []
+      }
+      workout_checkins: {
+        Row: {
+          active_session_user_id: string | null
+          answers: Json
+          created_at: string
+          energy: number | null
+          id: string
+          kind: string
+          mood: number | null
+          notes: string | null
+          planned_workout_id: string | null
+          sleep_hours: number | null
+          soreness: number | null
+          updated_at: string
+          user_id: string
+          weight_kg: number | null
+          workout_id: string | null
+        }
+        Insert: {
+          active_session_user_id?: string | null
+          answers?: Json
+          created_at?: string
+          energy?: number | null
+          id?: string
+          kind: string
+          mood?: number | null
+          notes?: string | null
+          planned_workout_id?: string | null
+          sleep_hours?: number | null
+          soreness?: number | null
+          updated_at?: string
+          user_id: string
+          weight_kg?: number | null
+          workout_id?: string | null
+        }
+        Update: {
+          active_session_user_id?: string | null
+          answers?: Json
+          created_at?: string
+          energy?: number | null
+          id?: string
+          kind?: string
+          mood?: number | null
+          notes?: string | null
+          planned_workout_id?: string | null
+          sleep_hours?: number | null
+          soreness?: number | null
+          updated_at?: string
+          user_id?: string
+          weight_kg?: number | null
+          workout_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workout_checkins_active_session_user_id_fkey"
+            columns: ["active_session_user_id"]
+            isOneToOne: false
+            referencedRelation: "active_workout_sessions"
+            referencedColumns: ["user_id"]
+          },
+          {
+            foreignKeyName: "workout_checkins_planned_workout_id_fkey"
+            columns: ["planned_workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_checkins_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_checkins_workout_id_fkey"
+            columns: ["workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workout_session_logs: {
+        Row: {
+          created_at: string | null
+          duration_seconds: number | null
+          finished_at: string
+          id: string
+          idempotency_key: string | null
+          metadata: Json | null
+          started_at: string
+          total_reps: number | null
+          total_sets: number | null
+          total_volume: number | null
+          user_id: string
+          workout_id: string | null
+          workout_title: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          duration_seconds?: number | null
+          finished_at?: string
+          id?: string
+          idempotency_key?: string | null
+          metadata?: Json | null
+          started_at: string
+          total_reps?: number | null
+          total_sets?: number | null
+          total_volume?: number | null
+          user_id: string
+          workout_id?: string | null
+          workout_title?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          duration_seconds?: number | null
+          finished_at?: string
+          id?: string
+          idempotency_key?: string | null
+          metadata?: Json | null
+          started_at?: string
+          total_reps?: number | null
+          total_sets?: number | null
+          total_volume?: number | null
+          user_id?: string
+          workout_id?: string | null
+          workout_title?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workout_session_logs_workout_id_fkey"
+            columns: ["workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workout_set_logs: {
+        Row: {
+          created_at: string | null
+          exercise_id: string | null
+          exercise_name: string
+          id: string
+          is_warmup: boolean | null
+          method: string | null
+          muscle_group: string | null
+          reps: number | null
+          rpe: number | null
+          session_id: string
+          set_number: number
+          volume: number | null
+          weight: number | null
+        }
+        Insert: {
+          created_at?: string | null
+          exercise_id?: string | null
+          exercise_name: string
+          id?: string
+          is_warmup?: boolean | null
+          method?: string | null
+          muscle_group?: string | null
+          reps?: number | null
+          rpe?: number | null
+          session_id: string
+          set_number?: number
+          volume?: number | null
+          weight?: number | null
+        }
+        Update: {
+          created_at?: string | null
+          exercise_id?: string | null
+          exercise_name?: string
+          id?: string
+          is_warmup?: boolean | null
+          method?: string | null
+          muscle_group?: string | null
+          reps?: number | null
+          rpe?: number | null
+          session_id?: string
+          set_number?: number
+          volume?: number | null
+          weight?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workout_set_logs_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_set_logs_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "workout_session_logs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workout_sync_mappings: {
+        Row: {
+          created_at: string
+          id: string
+          source_workout_id: string
+          subscription_id: string
+          target_workout_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          source_workout_id: string
+          subscription_id: string
+          target_workout_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          source_workout_id?: string
+          subscription_id?: string
+          target_workout_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workout_sync_mappings_source_workout_id_fkey"
+            columns: ["source_workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_sync_mappings_subscription_id_fkey"
+            columns: ["subscription_id"]
+            isOneToOne: false
+            referencedRelation: "workout_sync_subscriptions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_sync_mappings_target_workout_id_fkey"
+            columns: ["target_workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workout_sync_subscriptions: {
+        Row: {
+          active: boolean | null
+          created_at: string
+          id: string
+          is_active: boolean
+          source_user_id: string | null
+          student_id: string
+          target_user_id: string | null
+          teacher_id: string
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          source_user_id?: string | null
+          student_id: string
+          target_user_id?: string | null
+          teacher_id: string
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean | null
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          source_user_id?: string | null
+          student_id?: string
+          target_user_id?: string | null
+          teacher_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workout_sync_subscriptions_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workout_sync_subscriptions_teacher_id_fkey"
+            columns: ["teacher_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      workouts: {
+        Row: {
+          archived_at: string | null
+          completed_at: string | null
+          created_at: string | null
+          created_by: string | null
+          date: string | null
+          finish_idempotency_key: string | null
+          id: string
+          idempotency_key: string | null
+          is_template: boolean | null
+          name: string
+          notes: string | null
+          sort_order: number
+          source_workout_id: string | null
+          student_id: string | null
+          user_id: string | null
+        }
+        Insert: {
+          archived_at?: string | null
+          completed_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          date?: string | null
+          finish_idempotency_key?: string | null
+          id?: string
+          idempotency_key?: string | null
+          is_template?: boolean | null
+          name: string
+          notes?: string | null
+          sort_order?: number
+          source_workout_id?: string | null
+          student_id?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          archived_at?: string | null
+          completed_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          date?: string | null
+          finish_idempotency_key?: string | null
+          id?: string
+          idempotency_key?: string | null
+          is_template?: boolean | null
+          name?: string
+          notes?: string | null
+          sort_order?: number
+          source_workout_id?: string | null
+          student_id?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workouts_source_workout_id_fkey"
+            columns: ["source_workout_id"]
+            isOneToOne: false
+            referencedRelation: "workouts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "workouts_student_id_fkey"
+            columns: ["student_id"]
+            isOneToOne: false
+            referencedRelation: "students"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      accept_team_invite: { Args: { invite_id: string }; Returns: Json }
+      admin_get_vip_stats: {
+        Args: { period_end?: string; period_start?: string }
+        Returns: Json
+      }
+      approve_access_request: {
+        Args: {
+          p_actor_email?: string
+          p_actor_id?: string
+          p_actor_role?: string
+          p_request_id: string
+        }
+        Returns: Json
+      }
+      auth_role: { Args: never; Returns: string }
+      auth_uid: { Args: never; Returns: string }
+      can_dm_pair: {
+        Args: { p_user1: string; p_user2: string }
+        Returns: boolean
+      }
+      can_view_story: {
+        Args: { author: string; viewer: string }
+        Returns: boolean
+      }
+      can_view_team_session: {
+        Args: { p_session_id: string; p_uid: string }
+        Returns: boolean
+      }
+      cleanup_inactive_push_tokens: { Args: never; Returns: number }
+      create_recovery_codes: {
+        Args: { p_count?: number }
+        Returns: {
+          code: string
+          last4: string
+        }[]
+      }
+      dedupe_direct_channels: {
+        Args: never
+        Returns: {
+          channels_deduped: number
+          messages_moved: number
+          pairs_affected: number
+        }[]
+      }
+      delete_student_cascade: {
+        Args: {
+          p_actor_email?: string
+          p_actor_id?: string
+          p_actor_role?: string
+          p_student_id: string
+        }
+        Returns: Json
+      }
+      delete_teacher_cascade: {
+        Args: {
+          p_actor_email: string
+          p_actor_id: string
+          p_actor_role: string
+          p_teacher_id: string
+        }
+        Returns: Json
+      }
+      get_dashboard_bootstrap: { Args: { p_user_id: string }; Returns: Json }
+      get_or_create_direct_channel: {
+        Args: { user1: string; user2: string }
+        Returns: string
+      }
+      get_user_conversations: {
+        Args: { user_id: string }
+        Returns: {
+          channel_id: string
+          is_online: boolean
+          last_message: string
+          last_message_at: string
+          other_user_id: string
+          other_user_name: string
+          other_user_photo: string
+          unread_count: number
+        }[]
+      }
+      increment_counter: {
+        Args: { column_name: string; row_id: string; table_name: string }
+        Returns: undefined
+      }
+      iron_rank_leaderboard: {
+        Args: { limit_count: number }
+        Returns: {
+          display_name: string
+          photo_url: string
+          role: string
+          total_volume_kg: number
+          user_id: string
+        }[]
+      }
+      iron_rank_my_total_volume: { Args: never; Returns: number }
+      is_admin: { Args: never; Returns: boolean }
+      is_teacher_of: { Args: { target_user_id: string }; Returns: boolean }
+      join_team_session_by_code: { Args: { code: string }; Returns: Json }
+      jsonb_participants_has_uid: {
+        Args: { participants: Json; uid: string }
+        Returns: boolean
+      }
+      leave_team_session: { Args: { p_session_id: string }; Returns: Json }
+      nutrition_add_meal_entry: {
+        Args: {
+          p_calories?: number
+          p_carbs?: number
+          p_date: string
+          p_fat?: number
+          p_food_name: string
+          p_protein?: number
+        }
+        Returns: {
+          calories: number
+          carbs: number
+          date: string
+          entry_id: string
+          fat: number
+          food_name: string
+          protein: number
+          totals_calories: number
+          totals_carbs: number
+          totals_fat: number
+          totals_protein: number
+          user_id: string
+        }[]
+      }
+      nutrition_delete_meal_entry: {
+        Args: { p_entry_id: string }
+        Returns: {
+          date: string
+          deleted_entry_id: string
+          totals_calories: number
+          totals_carbs: number
+          totals_fat: number
+          totals_protein: number
+          user_id: string
+        }[]
+      }
+      save_workout_atomic: {
+        Args: {
+          p_created_by: string
+          p_exercises: Json
+          p_is_template: boolean
+          p_name: string
+          p_notes: string
+          p_user_id: string
+          p_workout_id: string
+        }
+        Returns: string
+      }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
+      teacher_can_add_student: {
+        Args: { p_teacher_user_id: string }
+        Returns: boolean
+      }
+      teacher_student_count: {
+        Args: { p_teacher_user_id: string }
+        Returns: number
+      }
+      try_parse_jsonb:
+        | { Args: { p_json: Json }; Returns: Json }
+        | { Args: { p_text: string }; Returns: Json }
+      try_parse_numeric: { Args: { p_text: string }; Returns: number }
+      users_share_private_channel: {
+        Args: { p_a: string; p_b: string }
+        Returns: boolean
+      }
+      verify_recovery_code: { Args: { p_code: string }; Returns: boolean }
+      verify_recovery_code_admin: {
+        Args: { p_code: string; p_user_id: string }
+        Returns: boolean
+      }
+    }
+    Enums: {
+      error_report_status: "new" | "triaged" | "resolved" | "ignored"
+      exercise_execution_submission_status: "pending" | "approved" | "rejected"
+      social_follow_status: "pending" | "accepted"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
 }
 
-export type DropSetConfig = DropSetStep[]
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-export type RestPauseConfig = {
-  weight: number | null
-  initial_reps: number | null
-  rest_time_sec: number | null
-  mini_sets: number | null
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
 }
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
 
-export type ClusterSetConfig = {
-  weight: number | null
-  total_reps: number | null
-  cluster_size: number | null
-  intra_rest_sec: number | null
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
 }
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
 
-export type SetAdvancedConfig = DropSetConfig | RestPauseConfig | ClusterSetConfig | null
-
-export type SetRow = {
-  id: string
-  exercise_id: string
-  weight: number | null
-  reps: string | null
-  rpe: number | null
-  set_number: number | null
-  completed: boolean | null
-  is_warmup: boolean | null
-  advanced_config: SetAdvancedConfig
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
 }
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
 
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      error_report_status: ["new", "triaged", "resolved", "ignored"],
+      exercise_execution_submission_status: ["pending", "approved", "rejected"],
+      social_follow_status: ["pending", "accepted"],
+    },
+  },
+} as const

--- a/src/types/workout.ts
+++ b/src/types/workout.ts
@@ -10,6 +10,7 @@ export const SetDetailSchema = z.object({
     is_warmup: z.boolean().optional(),
     completed: z.boolean().optional(),
     advanced_config: z.unknown().nullable().optional(),
+    duration_seconds: z.number().int().positive().nullable().optional(),
 })
 export type SetDetail = z.infer<typeof SetDetailSchema>
 
@@ -100,6 +101,7 @@ export interface WorkoutSet {
     isWarmup: boolean
     advancedConfig?: unknown
     completed?: boolean
+    durationSeconds?: number | null
 }
 
 export interface CheckinRow {

--- a/src/utils/__tests__/exerciseTracking.test.ts
+++ b/src/utils/__tests__/exerciseTracking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isPlank } from '../exerciseTracking'
+import { isPlank, isUnilateralByName } from '../exerciseTracking'
 
 describe('isPlank', () => {
   it.each([
@@ -35,5 +35,37 @@ describe('isPlank', () => {
 
   it('ignora espaços em branco nas bordas', () => {
     expect(isPlank('  Prancha  ')).toBe(true)
+  })
+})
+
+describe('isUnilateralByName', () => {
+  it.each([
+    'Cadeira flexora unilateral',
+    'Rosca direta unilateral',
+    'Unilateral dumbbell row',
+    'Agachamento búlgaro unilateral',
+    'UNILATERAL',
+  ])('retorna true para %s', (name) => {
+    expect(isUnilateralByName(name)).toBe(true)
+  })
+
+  it.each([
+    'Supino',
+    'Agachamento',
+    'Cadeira flexora',
+    'Leg press 45°',
+    'Hip thrust com barra',
+    '',
+  ])('retorna false para %s', (name) => {
+    expect(isUnilateralByName(name)).toBe(false)
+  })
+
+  it('retorna false para entradas nulas/undefined', () => {
+    expect(isUnilateralByName(null as unknown as string)).toBe(false)
+    expect(isUnilateralByName(undefined as unknown as string)).toBe(false)
+  })
+
+  it('ignora espaços em branco nas bordas', () => {
+    expect(isUnilateralByName('  Cadeira flexora unilateral  ')).toBe(true)
   })
 })

--- a/src/utils/__tests__/exerciseTracking.test.ts
+++ b/src/utils/__tests__/exerciseTracking.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { isPlank } from '../exerciseTracking'
+
+describe('isPlank', () => {
+  it.each([
+    'Prancha',
+    'prancha',
+    'Prancha lateral',
+    'Prancha com toques no ombro',
+    'Plank',
+    'plank',
+    'Side plank',
+    'PRANCHA',
+  ])('retorna true para %s', (name) => {
+    expect(isPlank(name)).toBe(true)
+  })
+
+  it.each([
+    'Supino',
+    'Agachamento',
+    'Rosca direta',
+    'Bird-dog',
+    'Dead bug',
+    'Abdominal',
+    'Abdominal infra',
+    '',
+  ])('retorna false para %s', (name) => {
+    expect(isPlank(name)).toBe(false)
+  })
+
+  it('retorna false para entradas nulas/undefined', () => {
+    expect(isPlank(null as unknown as string)).toBe(false)
+    expect(isPlank(undefined as unknown as string)).toBe(false)
+  })
+
+  it('ignora espaços em branco nas bordas', () => {
+    expect(isPlank('  Prancha  ')).toBe(true)
+  })
+})

--- a/src/utils/__tests__/formatSetSummary.test.ts
+++ b/src/utils/__tests__/formatSetSummary.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { formatSetSummary } from '../formatSetSummary'
+
+describe('formatSetSummary', () => {
+  it('Prancha com duration_seconds novo formato: "60s × 82 kg"', () => {
+    const out = formatSetSummary(
+      { weight: 82, reps: null, duration_seconds: 60 },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s × 82 kg')
+  })
+
+  it('Prancha legado (reps="60", duration_seconds=null): fallback para reps como segundos', () => {
+    const out = formatSetSummary(
+      { weight: 82, reps: '60', duration_seconds: null },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s × 82 kg')
+  })
+
+  it('Prancha sem peso: apenas "60s"', () => {
+    const out = formatSetSummary(
+      { weight: null, reps: null, duration_seconds: 60 },
+      { name: 'Prancha' },
+    )
+    expect(out).toBe('60s')
+  })
+
+  it('Supino (não-prancha): "10 × 80 kg"', () => {
+    const out = formatSetSummary(
+      { weight: 80, reps: '10', duration_seconds: null },
+      { name: 'Supino reto' },
+    )
+    expect(out).toBe('10 × 80 kg')
+  })
+
+  it('Supino sem peso: "10"', () => {
+    const out = formatSetSummary(
+      { weight: null, reps: '10', duration_seconds: null },
+      { name: 'Supino reto' },
+    )
+    expect(out).toBe('10')
+  })
+
+  it('Set vazio retorna string vazia', () => {
+    expect(formatSetSummary({ weight: null, reps: null, duration_seconds: null }, { name: 'Supino reto' })).toBe('')
+  })
+})

--- a/src/utils/__tests__/mapWorkoutRow.test.ts
+++ b/src/utils/__tests__/mapWorkoutRow.test.ts
@@ -154,6 +154,48 @@ describe('mapWorkoutRow', () => {
     })
   })
 
+  describe('unilateral flag preservation', () => {
+    it('maps is_unilateral → isUnilateral when true', () => {
+      const row = {
+        exercises: [{
+          id: 'e1', name: 'Cadeira flexora unilateral', order: 1,
+          is_unilateral: true, side_rest_time: 30, transition_time: null,
+          sets: [],
+        }],
+      }
+      const r = mapWorkoutRow(row)
+      const exs = r.exercises as { isUnilateral: boolean; sideRestTime: number | null; transitionTime: number | null }[]
+      expect(exs[0].isUnilateral).toBe(true)
+      expect(exs[0].sideRestTime).toBe(30)
+      expect(exs[0].transitionTime).toBeNull()
+    })
+
+    it('maps is_unilateral → isUnilateral false when absent', () => {
+      const row = {
+        exercises: [{
+          id: 'e1', name: 'Supino', order: 1, sets: [],
+        }],
+      }
+      const r = mapWorkoutRow(row)
+      const exs = r.exercises as { isUnilateral: boolean }[]
+      expect(exs[0].isUnilateral).toBe(false)
+    })
+
+    it('preserves sideRestTime and transitionTime independently', () => {
+      const row = {
+        exercises: [{
+          id: 'e1', name: 'Ex', order: 1,
+          is_unilateral: true, side_rest_time: 45, transition_time: 10,
+          sets: [],
+        }],
+      }
+      const r = mapWorkoutRow(row)
+      const exs = r.exercises as { sideRestTime: number; transitionTime: number }[]
+      expect(exs[0].sideRestTime).toBe(45)
+      expect(exs[0].transitionTime).toBe(10)
+    })
+  })
+
   describe('edge cases', () => {
     it('handles null input', () => {
       const r = mapWorkoutRow(null)

--- a/src/utils/exerciseTracking.ts
+++ b/src/utils/exerciseTracking.ts
@@ -1,6 +1,18 @@
 const PLANK_REGEX = /\b(prancha|plank)\b/i
+const UNILATERAL_REGEX = /\bunilateral\b/i
 
 export function isPlank(exerciseName: string | null | undefined): boolean {
   if (!exerciseName || typeof exerciseName !== 'string') return false
   return PLANK_REGEX.test(exerciseName.trim())
+}
+
+/**
+ * Detect whether an exercise name hints at unilateral execution (L/R sides).
+ * Used as a fallback when the `is_unilateral` flag isn't set on the exercise
+ * record — so templates created before the flag existed (or imported without
+ * it) still render the unilateral modal automatically.
+ */
+export function isUnilateralByName(exerciseName: string | null | undefined): boolean {
+  if (!exerciseName || typeof exerciseName !== 'string') return false
+  return UNILATERAL_REGEX.test(exerciseName.trim())
 }

--- a/src/utils/exerciseTracking.ts
+++ b/src/utils/exerciseTracking.ts
@@ -1,0 +1,6 @@
+const PLANK_REGEX = /\b(prancha|plank)\b/i
+
+export function isPlank(exerciseName: string | null | undefined): boolean {
+  if (!exerciseName || typeof exerciseName !== 'string') return false
+  return PLANK_REGEX.test(exerciseName.trim())
+}

--- a/src/utils/formatSetSummary.ts
+++ b/src/utils/formatSetSummary.ts
@@ -1,0 +1,34 @@
+import { isPlank } from './exerciseTracking'
+
+type SetLike = {
+  weight?: number | null
+  reps?: string | number | null
+  duration_seconds?: number | null
+  durationSeconds?: number | null
+}
+
+type ExerciseLike = {
+  name?: string | null
+}
+
+export function formatSetSummary(set: SetLike, exercise: ExerciseLike): string {
+  const name = exercise?.name ?? ''
+  const weight = typeof set.weight === 'number' && set.weight > 0 ? set.weight : null
+  const weightStr = weight !== null ? ` × ${weight} kg` : ''
+
+  if (isPlank(name)) {
+    const duration =
+      (typeof set.duration_seconds === 'number' && set.duration_seconds > 0 ? set.duration_seconds : null) ??
+      (typeof set.durationSeconds === 'number' && set.durationSeconds > 0 ? set.durationSeconds : null) ??
+      (typeof set.reps === 'string' && /^\d+$/.test(set.reps.trim()) ? Number(set.reps) : null) ??
+      (typeof set.reps === 'number' && set.reps > 0 ? set.reps : null)
+    if (duration === null) return ''
+    return `${duration}s${weightStr}`
+  }
+
+  const repsNum =
+    (typeof set.reps === 'number' && set.reps > 0 ? set.reps : null) ??
+    (typeof set.reps === 'string' && set.reps.trim() !== '' ? set.reps.trim() : null)
+  if (repsNum === null) return ''
+  return `${repsNum}${weightStr}`
+}

--- a/src/utils/mapWorkoutRow.ts
+++ b/src/utils/mapWorkoutRow.ts
@@ -79,6 +79,9 @@ export const mapWorkoutRow = (w: unknown): Record<string, unknown> => {
                     reps: repsHeader,
                     rpe: rpeHeader,
                     setDetails,
+                    isUnilateral: !!e.is_unilateral,
+                    sideRestTime: e.side_rest_time ?? null,
+                    transitionTime: e.transition_time ?? null,
                 }
             } catch (mapErr) {
                 logError('Erro ao mapear exercício', {

--- a/src/utils/report/__tests__/setCompletion.test.ts
+++ b/src/utils/report/__tests__/setCompletion.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { isSetCompleted } from '../setCompletion'
+
+describe('isSetCompleted', () => {
+  it('returns false for nullish or non-object inputs', () => {
+    expect(isSetCompleted(null)).toBe(false)
+    expect(isSetCompleted(undefined)).toBe(false)
+    expect(isSetCompleted('done')).toBe(false)
+    expect(isSetCompleted(42)).toBe(false)
+  })
+
+  it('returns false for empty log', () => {
+    expect(isSetCompleted({})).toBe(false)
+  })
+
+  describe('primary signal: log.done', () => {
+    it('counts sets with done=true', () => {
+      expect(isSetCompleted({ done: true })).toBe(true)
+    })
+
+    it('counts sets with done="true" (string)', () => {
+      expect(isSetCompleted({ done: 'true' })).toBe(true)
+    })
+
+    it('does not count sets with done=false', () => {
+      expect(isSetCompleted({ done: false })).toBe(false)
+    })
+  })
+
+  describe('unilateral sets', () => {
+    it('counts unilateral set when both sides done', () => {
+      expect(isSetCompleted({ L_done: true, R_done: true })).toBe(true)
+    })
+
+    it('does not count unilateral set with only one side done', () => {
+      expect(isSetCompleted({ L_done: true })).toBe(false)
+      expect(isSetCompleted({ R_done: true })).toBe(false)
+    })
+
+    it('counts unilateral set with L_weight > 0 even if done flags missing (legacy)', () => {
+      expect(isSetCompleted({ L_weight: 30, R_weight: 30 })).toBe(true)
+    })
+
+    it('counts unilateral set with L_reps > 0 (legacy)', () => {
+      expect(isSetCompleted({ L_reps: '12' })).toBe(true)
+    })
+  })
+
+  describe('bilateral legacy sets (no done flag)', () => {
+    it('counts sets with weight > 0', () => {
+      expect(isSetCompleted({ weight: 80 })).toBe(true)
+    })
+
+    it('counts sets with reps > 0 (string)', () => {
+      expect(isSetCompleted({ reps: '10' })).toBe(true)
+    })
+
+    it('accepts comma decimal (pt-BR)', () => {
+      expect(isSetCompleted({ weight: '80,5' })).toBe(true)
+    })
+
+    it('rejects weight = 0 and reps = 0', () => {
+      expect(isSetCompleted({ weight: 0, reps: 0 })).toBe(false)
+      expect(isSetCompleted({ weight: '0', reps: '' })).toBe(false)
+    })
+  })
+
+  it('counts set marked done even without numeric values', () => {
+    expect(isSetCompleted({ done: true, weight: null, reps: null })).toBe(true)
+  })
+})

--- a/src/utils/report/setCompletion.ts
+++ b/src/utils/report/setCompletion.ts
@@ -1,0 +1,49 @@
+/**
+ * Single source of truth for "was this set completed?" in the client-side report.
+ *
+ * Historically the post-workout report counted a set as complete only when
+ * `log.weight > 0 || log.reps > 0`. That rule misses unilateral sets, which
+ * save their values in `L_weight`/`R_weight`/`L_reps`/`R_reps` and never
+ * populate the top-level `weight`/`reps`. The primary signal is `log.done`,
+ * which the set renderers set once the user marks the set done (both sides
+ * for unilateral exercises). Numeric fallbacks cover legacy sessions that
+ * predate the `done` flag or were imported without it.
+ */
+
+type SetLogLike = {
+  done?: unknown
+  L_done?: unknown
+  R_done?: unknown
+  weight?: unknown
+  reps?: unknown
+  L_weight?: unknown
+  R_weight?: unknown
+  L_reps?: unknown
+  R_reps?: unknown
+}
+
+const isTruthy = (v: unknown): boolean => {
+  if (v === true) return true
+  if (typeof v === 'string') return v.trim().toLowerCase() === 'true'
+  return false
+}
+
+const isPositiveNumber = (v: unknown): boolean => {
+  if (v == null || v === '') return false
+  const n = Number(String(v).replace(',', '.'))
+  return Number.isFinite(n) && n > 0
+}
+
+export function isSetCompleted(log: unknown): boolean {
+  if (!log || typeof log !== 'object') return false
+  const l = log as SetLogLike
+
+  if (isTruthy(l.done)) return true
+  if (isTruthy(l.L_done) && isTruthy(l.R_done)) return true
+
+  if (isPositiveNumber(l.weight) || isPositiveNumber(l.reps)) return true
+  if (isPositiveNumber(l.L_weight) || isPositiveNumber(l.R_weight)) return true
+  if (isPositiveNumber(l.L_reps) || isPositiveNumber(l.R_reps)) return true
+
+  return false
+}

--- a/supabase/migrations/20260420143352_add_duration_seconds_to_sets.sql
+++ b/supabase/migrations/20260420143352_add_duration_seconds_to_sets.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sets
+  ADD COLUMN duration_seconds INTEGER NULL
+  CHECK (duration_seconds IS NULL OR duration_seconds > 0);
+COMMENT ON COLUMN sets.duration_seconds
+  IS 'Duração em segundos para exercícios isométricos (ex: Prancha). NULL para exercícios baseados em reps.';


### PR DESCRIPTION
## Summary
Dois bugs independentes em exercícios unilaterais, mesma causa raiz (listas de campos hardcoded criadas antes da feature existir):

### Bug 1 — Modal não abre como unilateral
- `mapWorkoutRow.ts` é o normalizer snake→camel usado em **todo fetch de treino**
- Retornava apenas `id, name, notes, videoUrl, restTime, cadence, method, sets, reps, rpe, setDetails` — **sem** `isUnilateral/sideRestTime/transitionTime`
- Confirmado via runtime inspection + SQL: banco retorna `is_unilateral=true` (ex: Cadeira flexora unilateral do SEG), mas a flag era descartada no normalizer → render padrão bilateral
- **Fix:** adicionar os 3 campos no return + testes garantindo preservação

### Bug 2 — Séries unilaterais não contam no relatório
- `normalSet.tsx` salva valores em `L_weight`/`R_weight`/`L_reps`/`R_reps` — **nunca** no top-level
- `useReportData.ts` contava `weight > 0 || reps > 0` top-level → sempre 0 pra unilateral → série sumia do relatório cliente
- Divergia do servidor (`reportMetrics.ts`) que já contava por `log.done`
- **Fix:** novo helper puro `isSetCompleted(log)` que usa `log.done` como sinal primário + fallback numérico (top-level e L/R) pra legado

## Test plan
- [x] `npx tsc --noEmit` limpo
- [x] ESLint limpo
- [x] 1298 testes verdes (incluindo 3 novos em mapWorkoutRow + 14 em setCompletion)
- [x] Preview visual: Cadeira flexora unilateral agora renderiza com `LADO L` / `LADO R` e botões `✓ L ✓` / `✓ R ✓` automaticamente, sem precisar configurar manualmente

## Screenshots
Antes: inputs "Peso", "Reps", "RPE" (bilateral) + botão "OK" único
Depois: LADO L (azul) + LADO R (laranja), inputs separados, botões ✓ L ✓ / ✓ R ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)