### PR TITLE
fix: 4 melhorias no fluxo de treino (AUTO sticky, rate limit VIP, layout Grupo)

### DIFF
--- a/src/app/api/ai/post-workout-insights/route.ts
+++ b/src/app/api/ai/post-workout-insights/route.ts
@@ -163,24 +163,29 @@ export async function POST(req: Request) {
     const supabase = auth.supabase
     const userId = String(auth.user.id || '').trim()
 
-    const ip = getRequestIp(req)
-    const rl = await checkRateLimitAsync(`ai:post-workout-insights:${userId}:${ip}`, 15, 60_000)
-    if (!rl.allowed) {
-      return NextResponse.json(
-        { ok: false, error: 'rate_limited' },
-        { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
-      )
-    }
-
-    // Check VIP Limits (Counts as Insights Weekly)
+    // Check VIP weekly quota first — paying tiers are already bounded by their
+    // weekly limit, so they bypass the abuse rate limiter below. Free tier
+    // still goes through rate limiting to protect the endpoint.
     const { allowed, limit, tier } = await checkVipFeatureAccess(supabase, userId, 'insights_weekly');
     if (!allowed) {
-        return NextResponse.json({ 
+        return NextResponse.json({
             ok: false,
-            error: 'Limit Reached', 
+            error: 'Limit Reached',
             message: `Você atingiu o limite semanal de ${limit} insights do seu plano ${tier}. Faça upgrade para continuar.`,
             upgradeRequired: true
         }, { status: 403 });
+    }
+
+    const isFreeTier = !tier || tier === 'free'
+    if (isFreeTier) {
+      const ip = getRequestIp(req)
+      const rl = await checkRateLimitAsync(`ai:post-workout-insights:${userId}:${ip}`, 15, 60_000)
+      if (!rl.allowed) {
+        return NextResponse.json(
+          { ok: false, error: 'rate_limited' },
+          { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
+        )
+      }
     }
 
     const apiKey = env.gemini.apiKey

--- a/src/components/StoryComposer.tsx
+++ b/src/components/StoryComposer.tsx
@@ -47,6 +47,7 @@ export default function StoryComposer({ open, session, onClose, calories }: Stor
     metrics: rawMetrics,
     loadMedia, onSelectLayout,
     onPiecePointerDown, onPiecePointerMove, onPiecePointerUp,
+    onGroupPointerDown, onGroupPointerMove, onGroupPointerUp,
     shareImage, postToIronTracks,
   } = useStoryComposer({ open, session, onClose, caloriesOverride: calories })
 
@@ -275,6 +276,31 @@ export default function StoryComposer({ open, session, onClose, calories }: Stor
                         })}
                       </div>
                     )}
+
+                    {layout === 'group' && (
+                      <div
+                        className={[
+                          'absolute inset-0 z-20 touch-none select-none cursor-grab active:cursor-grabbing',
+                          'flex items-center justify-center',
+                        ].join(' ')}
+                        onPointerDown={onGroupPointerDown}
+                        onPointerMove={(e) => onGroupPointerMove(e, previewRef.current?.getBoundingClientRect() ?? null)}
+                        onPointerUp={onGroupPointerUp}
+                        onPointerCancel={onGroupPointerUp}
+                      >
+                        <span
+                          className={[
+                            'pointer-events-none px-3 py-1.5 rounded-full border text-[10px] font-black uppercase tracking-widest shadow-lg transition-all',
+                            draggingKey === '__group__'
+                              ? 'bg-yellow-500 text-black border-yellow-500 scale-110'
+                              : 'bg-black/60 backdrop-blur text-white border-white/30',
+                          ].join(' ')}
+                        >
+                          ARRASTAR GRUPO
+                        </span>
+                      </div>
+                    )}
+
                             {selectedSticker && (() => {
                           const stk = STICKERS.find(s => s.id === selectedSticker)
                           if (!stk) return null

--- a/src/components/stories/useStoryComposer.ts
+++ b/src/components/stories/useStoryComposer.ts
@@ -43,6 +43,15 @@ export function useStoryComposer({ open, session, onClose, caloriesOverride }: U
     const videoRef = useRef<HTMLVideoElement>(null)
     const compositorRef = useRef<VideoCompositor | null>(null)
     const dragRef = useRef({ key: null as string | null, pointerId: null as number | null, startX: 0, startY: 0, startPos: { x: 0, y: 0 } })
+    // Group-drag mirrors the LIVE per-piece drag, but tracks the start positions
+    // of all 6 pieces so a single pointer move can apply the same delta to each.
+    const groupDragRef = useRef<{
+        active: boolean
+        pointerId: number | null
+        startX: number
+        startY: number
+        startPositions: LivePositions
+    }>({ active: false, pointerId: null, startX: 0, startY: 0, startPositions: DEFAULT_LIVE_POSITIONS })
     const [mediaLoadIdRef] = useState({ current: 0 })
     const backgroundUrlRef = useRef('')
 
@@ -323,13 +332,68 @@ export function useStoryComposer({ open, session, onClose, caloriesOverride }: U
         } catch { }
     }, [])
 
+    const onGroupPointerDown = useCallback((e: React.PointerEvent<HTMLElement>) => {
+        try {
+            if (layout !== 'group' || !e?.currentTarget || typeof e?.pointerId !== 'number') return
+            e.preventDefault?.(); e.stopPropagation?.()
+            const startPositions = livePositions ?? DEFAULT_LIVE_POSITIONS
+            groupDragRef.current = { active: true, pointerId: e.pointerId, startX: e.clientX, startY: e.clientY, startPositions }
+            setDraggingKey('__group__')
+            e.currentTarget?.setPointerCapture?.(e.pointerId)
+        } catch { }
+    }, [layout, livePositions])
+
+    const onGroupPointerMove = useCallback((e: React.PointerEvent<HTMLElement>, previewRect: DOMRect | null) => {
+        try {
+            if (layout !== 'group') return
+            const { active, pointerId, startX, startY, startPositions } = groupDragRef.current
+            if (!active || typeof pointerId !== 'number' || e?.pointerId !== pointerId) return
+            if (!previewRect?.width || !previewRect?.height) return
+            e.preventDefault?.(); e.stopPropagation?.()
+            const dxPct = (Number(e.clientX) - Number(startX)) / previewRect.width
+            const dyPct = (Number(e.clientY) - Number(startY)) / previewRect.height
+            // Apply the proposed delta to every piece, clamp each, then take the
+            // most-constrained delta back so the whole group moves as one unit.
+            const keys = Object.keys(startPositions) as (keyof LivePositions)[]
+            let actualDx = dxPct
+            let actualDy = dyPct
+            for (const k of keys) {
+                const start = startPositions[k] ?? { x: 0, y: 0 }
+                const proposed = { x: start.x + dxPct, y: start.y + dyPct }
+                const clamped = clampPctWithSize({ pos: proposed, size: getSizeForKey(String(k)) })
+                const realDx = clamped.x - start.x
+                const realDy = clamped.y - start.y
+                if (Math.abs(realDx) < Math.abs(actualDx)) actualDx = realDx
+                if (Math.abs(realDy) < Math.abs(actualDy)) actualDy = realDy
+            }
+            const next: LivePositions = { ...startPositions }
+            for (const k of keys) {
+                const start = startPositions[k] ?? { x: 0, y: 0 }
+                next[k] = { x: start.x + actualDx, y: start.y + actualDy }
+            }
+            setLivePositions(next)
+        } catch { }
+    }, [layout, getSizeForKey])
+
+    const onGroupPointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
+        try {
+            const { active, pointerId } = groupDragRef.current
+            if (!active || typeof pointerId !== 'number' || e?.pointerId !== pointerId) return
+            e.preventDefault?.(); e.stopPropagation?.()
+            e.currentTarget?.releasePointerCapture?.(pointerId)
+            groupDragRef.current = { active: false, pointerId: null, startX: 0, startY: 0, startPositions: livePositions ?? DEFAULT_LIVE_POSITIONS }
+            setDraggingKey(null)
+        } catch { }
+    }, [livePositions])
+
     const onSelectLayout = useCallback((nextLayout: string) => {
         try {
             setLayout(safeString(nextLayout) || 'bottom-row')
             setDraggingKey(null)
             dragRef.current = { key: null, pointerId: null, startX: 0, startY: 0, startPos: { x: 0, y: 0 } }
+            groupDragRef.current = { active: false, pointerId: null, startX: 0, startY: 0, startPositions: livePositions ?? DEFAULT_LIVE_POSITIONS }
         } catch { setLayout('bottom-row') }
-    }, [])
+    }, [livePositions])
 
     // Canvas helpers
     const renderVideoFrameAsJpeg = async (vid: HTMLVideoElement): Promise<{ blob: Blob; filename: string; mime: string }> => {
@@ -513,6 +577,7 @@ export function useStoryComposer({ open, session, onClose, caloriesOverride }: U
         // handlers
         loadMedia, onSelectLayout,
         onPiecePointerDown, onPiecePointerMove, onPiecePointerUp,
+        onGroupPointerDown, onGroupPointerMove, onGroupPointerUp,
         shareImage, postToIronTracks,
     }
 }

--- a/src/components/storyComposerUtils.ts
+++ b/src/components/storyComposerUtils.ts
@@ -59,6 +59,7 @@ export const STORY_LAYOUTS: LayoutOption[] = [
     { id: 'left-stack', label: 'Esquerda' },
     { id: 'top-row', label: 'Topo' },
     { id: 'live', label: 'LIVE' },
+    { id: 'group', label: 'Grupo' },
 ];
 
 // Safe-area-aware defaults for LIVE layout
@@ -524,7 +525,7 @@ export const drawStory = ({
 
     const layoutId = STORY_LAYOUTS.some((l) => l.id === layout) ? layout : 'bottom-row';
 
-    if (layoutId === 'live') {
+    if (layoutId === 'live' || layoutId === 'group') {
         const safe =
             livePositions && typeof livePositions === 'object' ? livePositions : DEFAULT_LIVE_POSITIONS;
         const sizes = computeLiveSizes({ ctx, metrics });

--- a/src/components/workout/RestTimerOverlay.tsx
+++ b/src/components/workout/RestTimerOverlay.tsx
@@ -59,9 +59,25 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
     // Without this, the overlay stays visible for 1-2 frames after tap, during which
     // re-renders can interfere with the button's click handling on iOS WKWebView.
     const [dismissed, setDismissed] = useState(false);
-    // AUTO: local-only toggle (never persisted). Defaults OFF every session.
-    // When ON, the overlay auto-advances 500 ms after the countdown reaches zero.
-    const [autoLocal, setAutoLocal] = useState(false);
+    // AUTO: persisted in localStorage so the user's preference survives across
+    // sets, sessions and app restarts. When ON, the overlay auto-advances 500 ms
+    // after the countdown reaches zero.
+    const [autoLocal, setAutoLocal] = useState<boolean>(() => {
+        if (typeof window === 'undefined') return false;
+        try {
+            return window.localStorage.getItem('irontracks.restTimerAuto.v1') === '1';
+        } catch {
+            return false;
+        }
+    });
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            window.localStorage.setItem('irontracks.restTimerAuto.v1', autoLocal ? '1' : '0');
+        } catch {
+            /* storage unavailable — preference simply won't persist */
+        }
+    }, [autoLocal]);
     const warnedRef = useRef(false);
     const notifyIdRef = useRef('');
     const soundIntervalRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/lib/api/_fetch.ts
+++ b/src/lib/api/_fetch.ts
@@ -28,7 +28,10 @@ export interface ApiResponse<T = unknown> {
   error?: string
 }
 
-const RETRYABLE_STATUSES = new Set([408, 429, 502, 503, 504])
+// 429 is intentionally excluded — rate-limit responses should fail fast so the
+// UI can show the message immediately. Retrying just amplifies one user click
+// into 3 server hits and delays the error feedback by ~1.6s.
+const RETRYABLE_STATUSES = new Set([408, 502, 503, 504])
 
 /**
  * Core fetch wrapper — throws ApiError on non-ok responses.


### PR DESCRIPTION
## Summary

Combina 4 fixes pequenos descobertos durante teste do branch original (pause timer):

1. **AUTO rest-timer persistido** (`RestTimerOverlay.tsx`)
   - Toggle ao lado do START agora sobrevive entre sets/sessões via `localStorage` (`irontracks.restTimerAuto.v1`).

2. **Bypass de rate limit pra VIP em insights pós-treino** (`api/ai/post-workout-insights/route.ts`)
   - Quota semanal VIP agora é checada antes do rate limit. Tiers pagos (`vip_*`) pulam o limiter de 15/60s — já são limitados pela quota semanal. Free tier continua com a proteção.

3. **`apiFetch` não retenta mais 429s** (`lib/api/_fetch.ts`)
   - Antes: 1 clique que batesse no rate limit virava 3 chamadas com ~1.6s de delay. Agora 429 falha rápido. Vale pra qualquer rota com rate limit.

4. **Layout "Grupo" no Story Composer** (`storyComposerUtils.ts`, `useStoryComposer.ts`, `StoryComposer.tsx`)
   - 6º layout. Mantém a formação Normal mas arrastável como bloco único — útil pra ajeitar as métricas em volta da pessoa na foto sem ter que posicionar peça por peça como no LIVE.

## Test plan

- [ ] Toque AUTO uma vez → fecha/reabre treino → segue ON
- [ ] Clique "Gerar" em Insights pós-treino (VIP) → não dá mais "Muitas tentativas em sequência"
- [ ] Story → seleciona "Grupo" → arrasta o canvas → todas as 6 peças se movem juntas, param na safe zone
- [ ] iOS TestFlight: `npm run cap:sync && npm run ios:release` após merge

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b