### PR TITLE
fix(stories): Grupo começa com título/subtítulo agrupados nos cards (igual Normal)

### DIFF
--- a/src/components/stories/useStoryComposer.ts
+++ b/src/components/stories/useStoryComposer.ts
@@ -18,6 +18,7 @@ import {
     CANVAS_W,
     CANVAS_H,
     DEFAULT_LIVE_POSITIONS,
+    DEFAULT_GROUP_POSITIONS,
     isIOSUserAgent,
     parseExt,
     extFromMime,
@@ -388,10 +389,17 @@ export function useStoryComposer({ open, session, onClose, caloriesOverride }: U
 
     const onSelectLayout = useCallback((nextLayout: string) => {
         try {
-            setLayout(safeString(nextLayout) || 'bottom-row')
+            const safeNext = safeString(nextLayout) || 'bottom-row'
+            setLayout(safeNext)
             setDraggingKey(null)
             dragRef.current = { key: null, pointerId: null, startX: 0, startY: 0, startPos: { x: 0, y: 0 } }
-            groupDragRef.current = { active: false, pointerId: null, startX: 0, startY: 0, startPositions: livePositions ?? DEFAULT_LIVE_POSITIONS }
+            // Entering Grupo always resets positions to its Normal-like default —
+            // the whole point of Grupo is "drag the bottom-row arrangement around
+            // as a unit", so starting from the user's leftover LIVE positions
+            // would defeat the purpose.
+            const nextPositions = safeNext === 'group' ? DEFAULT_GROUP_POSITIONS : livePositions
+            if (safeNext === 'group') setLivePositions(DEFAULT_GROUP_POSITIONS)
+            groupDragRef.current = { active: false, pointerId: null, startX: 0, startY: 0, startPositions: nextPositions ?? DEFAULT_LIVE_POSITIONS }
         } catch { setLayout('bottom-row') }
     }, [livePositions])
 

--- a/src/components/storyComposerUtils.ts
+++ b/src/components/storyComposerUtils.ts
@@ -74,6 +74,23 @@ export const DEFAULT_LIVE_POSITIONS: LivePositions = {
     cardKcal: { x: 0.654, y: 0.720 },
 };
 
+// Group layout starts with the same arrangement as the Normal (bottom-row)
+// layout: brand at top, title and subtitle clustered just above the cards at
+// the bottom. Numbers derive from bottom-row's drawStory math:
+//   cardTopY  = safeBottomY - 16 - cardH           = 934 → 934/1280 ≈ 0.730
+//   subtitleY = cardTopY - 52                       = 882 → 882/1280 ≈ 0.689
+//   titleY    = subtitleY - 16 - 2*titleLineH       = 778 → 778/1280 ≈ 0.608
+// (titleY uses the 2-line worst case so longer titles don't collide with the
+// subtitle pill.)
+export const DEFAULT_GROUP_POSITIONS: LivePositions = {
+    brand: { x: 0.078, y: 0.135 },
+    title: { x: 0.078, y: 0.608 },
+    subtitle: { x: 0.078, y: 0.689 },
+    cardVolume: { x: 0.078, y: 0.730 },
+    cardTempo: { x: 0.366, y: 0.730 },
+    cardKcal: { x: 0.654, y: 0.730 },
+};
+
 // ─── Helper Utilities ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Follow-up do PR #83. O layout Grupo estava herdando o `DEFAULT_LIVE_POSITIONS`, que posiciona título e subtítulo no topo do canvas (y≈0.225 / 0.340) — correto pro look distribuído do LIVE, errado pro Grupo.

Usuário relatou que esperava o Grupo começar com a mesma cara do Normal (título/subtítulo agrupados logo acima dos cards), pra depois arrastar tudo junto como um bloco.

## O que muda

- Novo `DEFAULT_GROUP_POSITIONS` em `storyComposerUtils.ts` espelhando a matemática do `bottom-row` no `drawStory` (subtitleY = cardTopY − 52, titleY = subtitleY − 16 − 2·titleLineH usando o pior caso de 2 linhas).
- `onSelectLayout` em `useStoryComposer.ts` reseta `livePositions` pro novo default sempre que o usuário entra no Grupo. Selecionar Grupo várias vezes sempre volta pra posição inicial limpa.
- Outros layouts (Normal/Direita/Esquerda/Topo/LIVE) inalterados.

## Test plan

- [ ] Story Composer → seleciona "Grupo" → confirma que título e subtítulo aparecem logo acima dos cards de volume/tempo/kcal (não no topo perto da brand)
- [ ] Arrasta o canvas → todas as 6 peças se movem juntas (regressão do PR #83)
- [ ] Sai do Grupo pra Normal e volta pro Grupo → confirma que reseta pra posição padrão
- [ ] iOS TestFlight: `npm run cap:sync && npm run ios:release`

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_