### PR TITLE
docs(claude): regra de auto-merge ao terminar tarefa via PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,16 @@ editar código
   → npm run scan:secrets        (se tocou configs)
   → npm run deploy              (commit + push + Vercel CI/CD)
 ```
+
+## Auto-merge ao terminar tarefa (quando trabalhando via PR)
+Quando o agente está desenvolvendo numa branch e abriu PR, o fluxo padrão ao terminar a tarefa é:
+
+1. Aguardar o `quality-check` do GitHub Actions ficar verde
+2. Marcar o PR como ready (sair de draft)
+3. Mergear com **squash** (mantém main com 1 commit por feature, casa com o histórico atual)
+4. Vercel deploya prod automático no push pra main
+
+Não é preciso pedir confirmação a cada PR — esta regra é a confirmação durável. Exceções em que o agente DEVE pedir antes de mergear:
+- Mudança em `middleware.ts`, fluxos de auth, schemas do banco com migration, ou pagamentos (RevenueCat/IAP)
+- CI vermelho ou flaky — investigar primeiro, não tentar contornar com `--no-verify` ou retry cego
+- PR com revisões humanas pendentes não resolvidas


### PR DESCRIPTION
## Summary

Adiciona ao `CLAUDE.md` a regra de auto-merge: ao terminar uma tarefa numa branch com PR aberto, o agente segue o fluxo padrão (esperar `quality-check` verde → ready → squash → Vercel deploy automático) sem precisar pedir confirmação a cada PR.

Lista de exceções em que ainda é obrigatório confirmar antes:
- Mudanças em `middleware.ts`, auth, schemas do banco com migration, RevenueCat/IAP
- CI vermelho/flaky
- Revisões humanas pendentes não resolvidas

Persiste a regra entre sessões e pra outros devs do time.

## Test plan

- [ ] Próxima tarefa via PR: agente mergeia sozinho ao final sem perguntar (caso normal)
- [ ] Próxima tarefa que toque auth/payments/schema: agente pergunta antes (caso exceção)

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_