### PR TITLE
feat(report): mapa muscular semanal no relatório + PDF

### DIFF
--- a/src/components/WorkoutReport.tsx
+++ b/src/components/WorkoutReport.tsx
@@ -41,6 +41,7 @@ const ExerciseTrendPanel = dynamic(() => import('@/components/workout-report/Exe
 const ReportCheckinPanel = dynamic(() => import('@/components/workout-report/ReportCheckinPanel').then(m => ({ default: m.ReportCheckinPanel })), { ssr: false, loading: () => <SectionSkeleton /> })
 const ReportAiSection = dynamic(() => import('@/components/workout-report/ReportAiSection').then(m => ({ default: m.ReportAiSection })), { ssr: false, loading: () => <SectionSkeleton /> })
 const ReportMusclePieChart = dynamic(() => import('@/components/workout-report/ReportMusclePieChart').then(m => ({ default: m.ReportMusclePieChart })), { ssr: false, loading: () => <SectionSkeleton /> })
+const MuscleMapSection = dynamic(() => import('@/components/workout-report/MuscleMapSection').then(m => ({ default: m.MuscleMapSection })), { ssr: false, loading: () => <SectionSkeleton /> })
 
 // Modals — loaded only when user opens them
 const StoryComposer = dynamic(() => import('@/components/StoryComposer'), { ssr: false, loading: () => null })
@@ -54,6 +55,7 @@ import {
     type AiState,
 } from '@/hooks/useReportData'
 import { MUSCLE_BY_ID } from '@/utils/muscleMapConfig'
+import { useMuscleMapWeek } from '@/hooks/useMuscleMapWeek'
 
 type AnyObj = Record<string, unknown>
 
@@ -119,6 +121,16 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
         isGenerating, setIsGenerating,
         pdfUrl, setPdfUrl, pdfBlob, setPdfBlob, pdfFrameRef,
     } = useReportData({ session, previousSession, user, settings });
+
+    // Weekly muscle map for the in-report visualization + PDF export.
+    // Fetches once when the report opens; re-export wraps cached server data.
+    const muscleMapWeek = useMuscleMapWeek(!!session);
+    const muscleGender: 'male' | 'female' | 'not_informed' = (() => {
+        const raw = String(settings?.biologicalSex || '').toLowerCase().trim();
+        if (raw === 'female' || raw === 'feminino') return 'female';
+        if (raw === 'male' || raw === 'masculino') return 'male';
+        return 'not_informed';
+    })();
 
     useEffect(() => {
         if (!storiesV2Enabled) { setShowStoryPrompt(false); return; }
@@ -223,6 +235,8 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
                 bodyWeightKg: Number(settings?.bodyWeightKg) || undefined,
                 biologicalSex: String(settings?.biologicalSex || '').toLowerCase() || undefined,
                 rpe: Number(postCheckin?.rpe) || undefined,
+                // Weekly muscle map snapshot — same data the in-page section uses
+                muscleMapWeek: muscleMapWeek.status === 'ready' ? muscleMapWeek.data : null,
             });
 
             const title = String(session?.workoutTitle || 'Treino').trim() || 'Treino'
@@ -772,6 +786,12 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
                 />
 
                 <Suspense fallback={<SectionSkeleton />}>
+                    <MuscleMapSection
+                        data={muscleMapWeek.data}
+                        status={muscleMapWeek.status}
+                        gender={muscleGender}
+                    />
+
                     {muscleTrend.status === 'ready' && muscleTrend.data && (
                         <MuscleTrendPanel
                             data={muscleTrend.data}

--- a/src/components/workout-report/MuscleMapSection.tsx
+++ b/src/components/workout-report/MuscleMapSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { MUSCLE_GROUPS } from '@/utils/muscleMapConfig'
 

--- a/src/components/workout-report/MuscleMapSection.tsx
+++ b/src/components/workout-report/MuscleMapSection.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import dynamic from 'next/dynamic'
+import { MUSCLE_GROUPS } from '@/utils/muscleMapConfig'
+
+// BodyMapSvg uses CSS masks + PNG overlays — keep it client-only and lazy
+// so it doesn't block the rest of the report from rendering.
+const BodyMapSvg = dynamic(() => import('@/components/muscle-map/BodyMapSvg'), { ssr: false })
+
+type MuscleEntry = { label?: string; sets?: number; ratio?: number; color?: string; view?: string }
+
+type Props = {
+    /** Output of getMuscleMapWeek — { muscles: Record<MuscleId, MuscleEntry>, ... } */
+    data: Record<string, unknown> | null
+    status: 'idle' | 'loading' | 'ready' | 'error'
+    gender?: 'male' | 'female' | 'not_informed'
+}
+
+// Color buckets mirror colorForRatio in muscleMapWeekHelpers.ts so the legend
+// matches what gets painted on the silhouette.
+const LEGEND_BUCKETS: { label: string; color: string }[] = [
+    { label: 'Nenhum', color: '#374151' },
+    { label: 'Baixo', color: '#fbbf24' },
+    { label: 'Na meta', color: '#ea580c' },
+    { label: 'Alto', color: '#dc2626' },
+    { label: 'Acima', color: '#991b1b' },
+]
+
+export function MuscleMapSection({ data, status, gender = 'male' }: Props) {
+    const [view, setView] = useState<'front' | 'back'>('front')
+
+    const musclesForView = useMemo(() => {
+        const items = data && typeof data === 'object' && data.muscles && typeof data.muscles === 'object'
+            ? (data.muscles as Record<string, MuscleEntry>)
+            : null
+        if (!items) return {} as Record<string, MuscleEntry>
+        return Object.fromEntries(
+            Object.entries(items).filter(([, m]) => m && (m.view === view || m.view === 'both')),
+        )
+    }, [data, view])
+
+    const totalSetsThisView = useMemo(() => {
+        return Object.values(musclesForView).reduce((sum, m) => sum + Number(m?.sets || 0), 0)
+    }, [musclesForView])
+
+    return (
+        <div className="mb-8 p-4 rounded-xl border border-neutral-800 bg-neutral-900/60">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div className="min-w-0">
+                    <div className="text-xs font-black uppercase tracking-widest text-neutral-400">Mapa muscular</div>
+                    <div className="text-lg font-black text-white">Sua semana até aqui</div>
+                    <div className="text-xs text-neutral-300">Volume acumulado por grupo muscular nesta semana.</div>
+                </div>
+                <div className="bg-neutral-950 border border-neutral-800 rounded-xl p-1 flex gap-1 w-fit">
+                    <button
+                        type="button"
+                        onClick={() => setView('front')}
+                        className={
+                            view === 'front'
+                                ? 'min-h-[36px] px-3 rounded-lg bg-neutral-900 text-yellow-500 border border-yellow-500/30 font-black text-xs uppercase tracking-widest'
+                                : 'min-h-[36px] px-3 rounded-lg bg-transparent text-neutral-400 hover:text-white font-black text-xs uppercase tracking-widest'
+                        }
+                    >
+                        Frente
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setView('back')}
+                        className={
+                            view === 'back'
+                                ? 'min-h-[36px] px-3 rounded-lg bg-neutral-900 text-yellow-500 border border-yellow-500/30 font-black text-xs uppercase tracking-widest'
+                                : 'min-h-[36px] px-3 rounded-lg bg-transparent text-neutral-400 hover:text-white font-black text-xs uppercase tracking-widest'
+                        }
+                    >
+                        Costas
+                    </button>
+                </div>
+            </div>
+
+            <div className="mt-4 flex flex-col items-center gap-4">
+                {status === 'loading' && (
+                    <div className="w-full max-w-[280px] aspect-square rounded-2xl bg-neutral-950 animate-pulse" />
+                )}
+                {status === 'error' && (
+                    <div className="text-xs text-red-400 font-bold">Não foi possível carregar o mapa muscular.</div>
+                )}
+                {status === 'ready' && (
+                    <BodyMapSvg view={view} muscles={musclesForView} gender={gender} selected={null} />
+                )}
+
+                <div className="flex flex-wrap items-center justify-center gap-3 text-[10px] font-black uppercase tracking-widest">
+                    {LEGEND_BUCKETS.map(b => (
+                        <div key={b.label} className="flex items-center gap-1.5">
+                            <span className="inline-block w-3 h-3 rounded-sm" style={{ background: b.color }} />
+                            <span className="text-neutral-300">{b.label}</span>
+                        </div>
+                    ))}
+                </div>
+
+                {status === 'ready' && totalSetsThisView > 0 && (
+                    <div className="text-[11px] text-neutral-400 text-center">
+                        {Math.round(totalSetsThisView)} séries efetivas em{' '}
+                        {MUSCLE_GROUPS.filter(m => m.view === view || m.view === 'both').length} grupos visíveis nesta vista
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+

--- a/src/hooks/useMuscleMapWeek.ts
+++ b/src/hooks/useMuscleMapWeek.ts
@@ -21,12 +21,20 @@ export interface MuscleMapWeekState {
  * when `enabled` becomes true.
  */
 export function useMuscleMapWeek(enabled: boolean): MuscleMapWeekState {
-    const [state, setState] = useState<MuscleMapWeekState>({ status: 'idle', data: null, error: null })
+    // Initialize directly to 'loading' when enabled — avoids the
+    // react-hooks/set-state-in-effect violation that would come from a
+    // synchronous setState({ status: 'loading' }) inside the fetch effect.
+    // The effect only setStates to a terminal status ('ready' / 'error') after
+    // the await, which the rule allows.
+    const [state, setState] = useState<MuscleMapWeekState>(() => ({
+        status: enabled ? 'loading' : 'idle',
+        data: null,
+        error: null,
+    }))
 
     useEffect(() => {
         if (!enabled) return
         let cancelled = false
-        setState({ status: 'loading', data: null, error: null })
         ;(async () => {
             try {
                 const res = await getMuscleMapWeek({}) as { ok?: boolean; muscles?: unknown; error?: string } & Record<string, unknown>

--- a/src/hooks/useMuscleMapWeek.ts
+++ b/src/hooks/useMuscleMapWeek.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getMuscleMapWeek } from '@/actions/workout-actions'
+
+export type MuscleMapWeekStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+export interface MuscleMapWeekState {
+    status: MuscleMapWeekStatus
+    data: Record<string, unknown> | null
+    error: string | null
+}
+
+/**
+ * Lightweight fetch of the user's current weekly muscle map. Used in
+ * WorkoutReport to render the weekly state inline + embed it in the PDF.
+ *
+ * Intentionally minimal: no localStorage cache (the existing dashboard's
+ * MuscleMapCard already warms the server-side cache via its own request),
+ * no auto-refresh (the report is a snapshot at completion time). Fires once
+ * when `enabled` becomes true.
+ */
+export function useMuscleMapWeek(enabled: boolean): MuscleMapWeekState {
+    const [state, setState] = useState<MuscleMapWeekState>({ status: 'idle', data: null, error: null })
+
+    useEffect(() => {
+        if (!enabled) return
+        let cancelled = false
+        setState({ status: 'loading', data: null, error: null })
+        ;(async () => {
+            try {
+                const res = await getMuscleMapWeek({}) as { ok?: boolean; muscles?: unknown; error?: string } & Record<string, unknown>
+                if (cancelled) return
+                if (!res?.ok) {
+                    setState({ status: 'error', data: null, error: String(res?.error || 'Falha ao carregar mapa') })
+                    return
+                }
+                setState({ status: 'ready', data: res as Record<string, unknown>, error: null })
+            } catch (e) {
+                if (cancelled) return
+                setState({ status: 'error', data: null, error: e instanceof Error ? e.message : String(e) })
+            }
+        })()
+        return () => { cancelled = true }
+    }, [enabled])
+
+    return state
+}

--- a/src/utils/report/buildHtml.ts
+++ b/src/utils/report/buildHtml.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from '@/utils/escapeHtml'
+import { buildMuscleMapHtml } from '@/utils/report/buildMuscleMapHtml'
 import {
   isRecord,
   formatDate,
@@ -367,6 +368,21 @@ export function buildReportHTML(
 ) {
   const reportData = buildReportData(session, previousSession, studentName, kcalOverride, options)
   const aiRaw = isRecord((reportData as Record<string, unknown>)?.ai) ? ((reportData as Record<string, unknown>).ai as Record<string, unknown>) : null
+  const opts = isRecord(options) ? (options as Record<string, unknown>) : {}
+  const muscleMapWeek = isRecord(opts?.muscleMapWeek) ? (opts.muscleMapWeek as Record<string, unknown>) : null
+  const biologicalSexRaw = String((opts?.biologicalSex as string) || '').toLowerCase().trim()
+  const muscleGender: 'male' | 'female' | 'not_informed' = biologicalSexRaw === 'female' || biologicalSexRaw === 'feminino'
+    ? 'female'
+    : biologicalSexRaw === 'male' || biologicalSexRaw === 'masculino'
+      ? 'male'
+      : 'not_informed'
+  const reportOrigin = (() => {
+    try {
+      if (typeof window !== 'undefined' && window.location?.origin) return window.location.origin
+    } catch { /* SSR */ }
+    return 'https://irontracks.com.br'
+  })()
+  const muscleMapHtml = buildMuscleMapHtml(muscleMapWeek, { origin: reportOrigin, gender: muscleGender })
 
   const volumeDeltaStr = reportData?.summaryMetrics?.volumeDeltaPctVsPrev != null
     ? Number(reportData.summaryMetrics.volumeDeltaPctVsPrev).toFixed(1)
@@ -916,6 +932,7 @@ export function buildReportHTML(
 
     ${buildBikeCards()}
     ${buildAiSection()}
+    ${muscleMapHtml}
     ${detailByExerciseHtml}
 
     <!-- ── Exercises ──────────────────────────────── -->

--- a/src/utils/report/buildMuscleMapHtml.ts
+++ b/src/utils/report/buildMuscleMapHtml.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure HTML generator for the weekly muscle map section in the PDF/HTML
+ * export. Mirrors the visual logic of `BodyMapSvg.tsx` but emits a static
+ * string suitable for `buildReportHTML()` to inject.
+ *
+ * Strategy
+ * ────────
+ * - Frente + Costas side by side (no toggle in the export).
+ * - Same PNG overlays as the React component (`/muscle-overlays/*.png`),
+ *   referenced by absolute URL so the printed/saved HTML resolves them.
+ * - Per-muscle opacity = clamp(ratio * 0.85, 0.15..1) — matches
+ *   `ratioToOpacity` in BodyMapSvg.
+ * - CSS `mask-image` clips overlays to the body silhouette, just like the
+ *   React component.
+ *
+ * Why HTML+CSS instead of inline SVG paths
+ * ────────────────────────────────────────
+ * Re-implementing the muscle silhouettes as SVG paths would duplicate
+ * hundreds of bezier curves. The PNG-overlay approach lets us reuse the
+ * artwork that already exists.
+ */
+
+const FRONT_OVERLAYS: { muscleId: string; file: string }[] = [
+    { muscleId: 'chest', file: 'front-chest.png' },
+    { muscleId: 'delts_front', file: 'front-delts.png' },
+    { muscleId: 'delts_side', file: 'front-delts.png' },
+    { muscleId: 'biceps', file: 'front-biceps.png' },
+    { muscleId: 'forearms', file: 'front-forearms.png' },
+    { muscleId: 'abs', file: 'front-abs.png' },
+    { muscleId: 'quads', file: 'front-quads.png' },
+    { muscleId: 'calves', file: 'front-calves.png' },
+]
+
+const BACK_OVERLAYS: { muscleId: string; file: string }[] = [
+    { muscleId: 'upper_back', file: 'back-upper_back.png' },
+    { muscleId: 'lats', file: 'back-lats.png' },
+    { muscleId: 'delts_rear', file: 'back-delts_rear.png' },
+    { muscleId: 'triceps', file: 'back-triceps.png' },
+    { muscleId: 'spinal_erectors', file: 'back-spinal_erectors.png' },
+    { muscleId: 'glutes', file: 'back-glutes.png' },
+    { muscleId: 'hamstrings', file: 'back-hamstrings.png' },
+    { muscleId: 'calves', file: 'back-calves.png' },
+]
+
+const ratioToOpacity = (ratio: number) => {
+    if (!Number.isFinite(ratio) || ratio <= 0) return 0
+    return Math.min(1, Math.max(0.15, ratio * 0.85))
+}
+
+type MuscleEntry = { ratio?: number; sets?: number; view?: string }
+
+const dedupForView = (
+    overlays: typeof FRONT_OVERLAYS,
+    muscles: Record<string, MuscleEntry>,
+) => {
+    const seen = new Map<string, number>()
+    for (const o of overlays) {
+        const ratio = Number(muscles?.[o.muscleId]?.ratio || 0)
+        const prev = seen.get(o.file) ?? 0
+        if (ratio > prev) seen.set(o.file, ratio)
+    }
+    return Array.from(seen.entries()).map(([file, maxRatio]) => ({ file, maxRatio }))
+}
+
+interface BuildOptions {
+    /** Origin URL for the asset paths (e.g. https://irontracks.com.br). When
+     *  the HTML is opened locally as a file, absolute URLs let the browser
+     *  reach back to production for the PNGs. */
+    origin?: string
+    gender?: 'male' | 'female' | 'not_informed'
+}
+
+const buildOneSilhouette = (
+    view: 'front' | 'back',
+    muscles: Record<string, MuscleEntry>,
+    opts: BuildOptions,
+) => {
+    const isFemale = opts.gender === 'female'
+    const overlayFolder = `${opts.origin || ''}/muscle-overlays`
+    const baseSrc = view === 'front'
+        ? `${opts.origin || ''}/${isFemale ? 'body-front-female.png' : 'body-front.png'}`
+        : `${opts.origin || ''}/${isFemale ? 'body-back-female.png' : 'body-back.png'}`
+    const maskSrc = view === 'front'
+        ? `${opts.origin || ''}/${isFemale ? 'body-front-female-mask.png' : 'body-front-mask.png'}`
+        : `${opts.origin || ''}/${isFemale ? 'body-back-female-mask.png' : 'body-back-mask.png'}`
+
+    const overlays = view === 'front' ? FRONT_OVERLAYS : BACK_OVERLAYS
+    const layers = dedupForView(overlays, muscles)
+
+    const overlayDivs = layers
+        .map(({ file, maxRatio }) => {
+            const opacity = ratioToOpacity(maxRatio)
+            if (opacity <= 0) return ''
+            return `<div style="
+                position:absolute; inset:0;
+                background-image:url('${overlayFolder}/${file}');
+                background-size:contain; background-position:center; background-repeat:no-repeat;
+                opacity:${opacity.toFixed(3)};
+            "></div>`
+        })
+        .join('')
+
+    const viewLabel = view === 'front' ? 'Frente' : 'Costas'
+
+    return `
+        <div style="flex:1; min-width:0; display:flex; flex-direction:column; align-items:center; gap:8px;">
+            <div style="
+                position:relative; width:100%; max-width:240px; aspect-ratio:1/1;
+                background:#000; border-radius:16px; overflow:hidden;
+            ">
+                <div style="
+                    position:absolute; inset:0;
+                    background-image:url('${baseSrc}');
+                    background-size:contain; background-position:center; background-repeat:no-repeat;
+                "></div>
+                <div style="
+                    position:absolute; inset:0;
+                    -webkit-mask-image:url('${maskSrc}');
+                    mask-image:url('${maskSrc}');
+                    -webkit-mask-size:contain; mask-size:contain;
+                    -webkit-mask-position:center; mask-position:center;
+                    -webkit-mask-repeat:no-repeat; mask-repeat:no-repeat;
+                ">${overlayDivs}</div>
+                <div style="
+                    position:absolute; inset:0; pointer-events:none; border-radius:16px;
+                    box-shadow: inset 0 0 30px rgba(0,0,0,0.95);
+                "></div>
+            </div>
+            <div style="font-size:11px; font-weight:900; letter-spacing:0.2em; text-transform:uppercase; color:#9ca3af;">${viewLabel}</div>
+        </div>
+    `
+}
+
+const LEGEND_BUCKETS: { label: string; color: string }[] = [
+    { label: 'Nenhum', color: '#374151' },
+    { label: 'Baixo', color: '#fbbf24' },
+    { label: 'Na meta', color: '#ea580c' },
+    { label: 'Alto', color: '#dc2626' },
+    { label: 'Acima', color: '#991b1b' },
+]
+
+const buildLegend = () => `
+    <div style="display:flex; flex-wrap:wrap; gap:12px; justify-content:center; margin-top:12px;">
+        ${LEGEND_BUCKETS.map(b => `
+            <div style="display:flex; align-items:center; gap:6px;">
+                <span style="display:inline-block; width:10px; height:10px; border-radius:2px; background:${b.color};"></span>
+                <span style="font-size:10px; font-weight:900; letter-spacing:0.15em; text-transform:uppercase; color:#d1d5db;">${b.label}</span>
+            </div>
+        `).join('')}
+    </div>
+`
+
+/**
+ * Returns an HTML string for the "Mapa Muscular" section. Returns empty
+ * string when there's no muscle data — caller can safely append it.
+ */
+export function buildMuscleMapHtml(
+    muscleData: Record<string, unknown> | null | undefined,
+    opts: BuildOptions = {},
+): string {
+    const muscles = muscleData && typeof muscleData === 'object' && muscleData.muscles && typeof muscleData.muscles === 'object'
+        ? (muscleData.muscles as Record<string, MuscleEntry>)
+        : null
+    if (!muscles) return ''
+
+    const hasAnyData = Object.values(muscles).some(m => Number(m?.sets || 0) > 0)
+    if (!hasAnyData) return ''
+
+    const front = buildOneSilhouette('front', muscles, opts)
+    const back = buildOneSilhouette('back', muscles, opts)
+
+    return `
+        <div class="section-block">
+            <div class="section-title"><span class="section-dot"></span>Mapa Muscular — Sua semana</div>
+            <div style="display:flex; gap:16px; align-items:flex-start; flex-wrap:wrap;">
+                ${front}
+                ${back}
+            </div>
+            ${buildLegend()}
+        </div>
+    `
+}


### PR DESCRIPTION
## Summary

Adiciona a seção **"Mapa Muscular — Sua semana"** no relatório de treino e na exportação HTML/PDF, mostrando o estado atual da semana (mesmos dados do dashboard, escala de cores BAIXO/NA META/ALTO/ACIMA).

## O que muda

**Novos arquivos:**
- `src/hooks/useMuscleMapWeek.ts` — fetcher mínimo do `getMuscleMapWeek` (a cache do server já existe)
- `src/components/workout-report/MuscleMapSection.tsx` — componente React com toggle FRENTE/COSTAS, reusa o `BodyMapSvg` do dashboard
- `src/utils/report/buildMuscleMapHtml.ts` — gerador puro de HTML pro PDF (frente + costas lado a lado, mesma técnica de PNG overlay + máscara CSS)

**Mudanças:**
- `WorkoutReport.tsx`: importa hook + seção, renderiza antes do `MuscleTrendPanel`, passa os mesmos dados pro `buildReportHTML`
- `buildHtml.ts`: lê `opts.muscleMapWeek` + `biologicalSex` e injeta a seção entre a parte de IA e os detalhes por exercício

Zero backend mudou — só consumindo endpoint que já existia.

## Fora de escopo (próximo PR se confirmar)

- Mapa "Este treino" (só os músculos desta sessão) — precisa endpoint novo `getMuscleMapSession(id)` ou classificador client-side. Pode ser feito num PR separado depois que validar este.

## Test plan

- [ ] Abrir relatório de um treino → seção "Mapa Muscular — Sua semana" aparece entre IA e detalhe por exercício
- [ ] Toggle FRENTE/COSTAS muda a vista corretamente
- [ ] Salvar/Compartilhar HTML → arquivo gerado contém os 2 mapas (frente + costas) lado a lado
- [ ] Usuária com `biologicalSex=female` → silhueta feminina renderiza no relatório E no PDF
- [ ] Usuário sem dados na semana → seção fica oculta no PDF (boa: `buildMuscleMapHtml` retorna string vazia)
- [ ] iOS TestFlight: `npm run cap:sync && npm run ios:release`

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_