### PR TITLE
fix(report): silhuetas do mapa muscular ficam pretas no PDF (embed base64)

### DIFF
--- a/src/components/WorkoutReport.tsx
+++ b/src/components/WorkoutReport.tsx
@@ -5,6 +5,7 @@ import NextImage from 'next/image';
 import { Download, ArrowLeft, FileText, Code, Share2, Save } from 'lucide-react';
 import { buildReportHTML } from '@/utils/report/buildHtml';
 import { fetchLogoDataUrl } from '@/utils/report/fetchLogoDataUrl';
+import { fetchMuscleMapAssets } from '@/utils/report/fetchMuscleMapAssets';
 import { workoutPlanHtml } from '@/utils/report/templates';
 import { generatePostWorkoutInsights, applyProgressionToNextTemplate } from '@/actions/workout-actions';
 import { useVipCredits } from '@/hooks/useVipCredits';
@@ -226,6 +227,12 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
                 } catch (e) { logError('component:WorkoutReport.generateAiForPdf', e) }
             }
             const logoDataUrl = await fetchLogoDataUrl().catch(() => null)
+            // Pre-fetch the muscle-map PNGs as base64. The exported HTML is
+            // opened in iOS share / file:// blob contexts that can't reach the
+            // origin for external images.
+            const muscleMapAssets = muscleMapWeek.status === 'ready'
+                ? await fetchMuscleMapAssets(muscleGender, muscleMapWeek.data).catch(() => null)
+                : null
             const html = buildReportHTML(sessionForReport, prevForReport, String(user?.displayName || user?.email || ''), calories, {
                 prevLogsByExercise: prevLogsForReport,
                 prevBaseMsByExercise: prevBaseForReport,
@@ -237,6 +244,7 @@ const WorkoutReport = ({ session, previousSession, user, isVip: _isVip, onClose,
                 rpe: Number(postCheckin?.rpe) || undefined,
                 // Weekly muscle map snapshot — same data the in-page section uses
                 muscleMapWeek: muscleMapWeek.status === 'ready' ? muscleMapWeek.data : null,
+                muscleMapAssets,
             });
 
             const title = String(session?.workoutTitle || 'Treino').trim() || 'Treino'

--- a/src/utils/report/buildHtml.ts
+++ b/src/utils/report/buildHtml.ts
@@ -382,7 +382,14 @@ export function buildReportHTML(
     } catch { /* SSR */ }
     return 'https://irontracks.com.br'
   })()
-  const muscleMapHtml = buildMuscleMapHtml(muscleMapWeek, { origin: reportOrigin, gender: muscleGender })
+  const muscleMapAssets = isRecord(opts?.muscleMapAssets) ? (opts.muscleMapAssets as {
+    baseFront: string | null
+    baseBack: string | null
+    maskFront: string | null
+    maskBack: string | null
+    overlays: Record<string, string>
+  }) : null
+  const muscleMapHtml = buildMuscleMapHtml(muscleMapWeek, { origin: reportOrigin, gender: muscleGender, assets: muscleMapAssets })
 
   const volumeDeltaStr = reportData?.summaryMetrics?.volumeDeltaPctVsPrev != null
     ? Number(reportData.summaryMetrics.volumeDeltaPctVsPrev).toFixed(1)

--- a/src/utils/report/buildMuscleMapHtml.ts
+++ b/src/utils/report/buildMuscleMapHtml.ts
@@ -63,11 +63,22 @@ const dedupForView = (
 }
 
 interface BuildOptions {
-    /** Origin URL for the asset paths (e.g. https://irontracks.com.br). When
-     *  the HTML is opened locally as a file, absolute URLs let the browser
-     *  reach back to production for the PNGs. */
+    /** Origin URL for the asset paths (e.g. https://irontracks.com.br). Used
+     *  only as a fallback when `assets` is not provided. */
     origin?: string
     gender?: 'male' | 'female' | 'not_informed'
+    /** Pre-fetched base64 data URLs for every PNG the silhouette needs.
+     *  Required for the export to render correctly in iOS share sheets /
+     *  file:// blobs / print previews — those contexts can't fetch external
+     *  resources. When null/undefined, falls back to `origin` URLs (only
+     *  works in normal browser tabs with network to the origin). */
+    assets?: {
+        baseFront: string | null
+        baseBack: string | null
+        maskFront: string | null
+        maskBack: string | null
+        overlays: Record<string, string>
+    } | null
 }
 
 const buildOneSilhouette = (
@@ -76,13 +87,15 @@ const buildOneSilhouette = (
     opts: BuildOptions,
 ) => {
     const isFemale = opts.gender === 'female'
-    const overlayFolder = `${opts.origin || ''}/muscle-overlays`
-    const baseSrc = view === 'front'
+    const assets = opts.assets ?? null
+    const baseFallback = view === 'front'
         ? `${opts.origin || ''}/${isFemale ? 'body-front-female.png' : 'body-front.png'}`
         : `${opts.origin || ''}/${isFemale ? 'body-back-female.png' : 'body-back.png'}`
-    const maskSrc = view === 'front'
+    const maskFallback = view === 'front'
         ? `${opts.origin || ''}/${isFemale ? 'body-front-female-mask.png' : 'body-front-mask.png'}`
         : `${opts.origin || ''}/${isFemale ? 'body-back-female-mask.png' : 'body-back-mask.png'}`
+    const baseSrc = (view === 'front' ? assets?.baseFront : assets?.baseBack) || baseFallback
+    const maskSrc = (view === 'front' ? assets?.maskFront : assets?.maskBack) || maskFallback
 
     const overlays = view === 'front' ? FRONT_OVERLAYS : BACK_OVERLAYS
     const layers = dedupForView(overlays, muscles)
@@ -91,9 +104,10 @@ const buildOneSilhouette = (
         .map(({ file, maxRatio }) => {
             const opacity = ratioToOpacity(maxRatio)
             if (opacity <= 0) return ''
+            const overlaySrc = assets?.overlays?.[file] || `${opts.origin || ''}/muscle-overlays/${file}`
             return `<div style="
                 position:absolute; inset:0;
-                background-image:url('${overlayFolder}/${file}');
+                background-image:url('${overlaySrc}');
                 background-size:contain; background-position:center; background-repeat:no-repeat;
                 opacity:${opacity.toFixed(3)};
             "></div>`

--- a/src/utils/report/fetchMuscleMapAssets.ts
+++ b/src/utils/report/fetchMuscleMapAssets.ts
@@ -1,0 +1,112 @@
+/**
+ * Pre-fetches every PNG the PDF muscle-map needs and returns them as base64
+ * data URLs so `buildMuscleMapHtml` can embed them inline.
+ *
+ * The exported HTML is opened by iOS share sheets / file:// blobs / print
+ * previews — contexts that can't reach back to https://irontracks.com.br for
+ * external resources. Same problem (and same fix) as `fetchLogoDataUrl`.
+ *
+ * Only fetches overlays for muscles with ratio > 0 to keep the payload small
+ * (~50–200 KB total instead of ~1 MB).
+ */
+
+const FRONT_OVERLAY_BY_MUSCLE: Record<string, string> = {
+    chest: 'front-chest.png',
+    delts_front: 'front-delts.png',
+    delts_side: 'front-delts.png',
+    biceps: 'front-biceps.png',
+    forearms: 'front-forearms.png',
+    abs: 'front-abs.png',
+    quads: 'front-quads.png',
+    calves: 'front-calves.png',
+}
+
+const BACK_OVERLAY_BY_MUSCLE: Record<string, string> = {
+    upper_back: 'back-upper_back.png',
+    lats: 'back-lats.png',
+    delts_rear: 'back-delts_rear.png',
+    triceps: 'back-triceps.png',
+    spinal_erectors: 'back-spinal_erectors.png',
+    glutes: 'back-glutes.png',
+    hamstrings: 'back-hamstrings.png',
+    calves: 'back-calves.png',
+}
+
+export interface MuscleMapAssets {
+    baseFront: string | null
+    baseBack: string | null
+    maskFront: string | null
+    maskBack: string | null
+    /** keyed by overlay filename (e.g. "front-chest.png") */
+    overlays: Record<string, string>
+}
+
+const _cache = new Map<string, string>()
+
+const fetchAsDataUrl = async (path: string): Promise<string | null> => {
+    const cached = _cache.get(path)
+    if (cached) return cached
+    try {
+        const res = await fetch(path)
+        if (!res.ok) return null
+        const blob = await res.blob()
+        return await new Promise<string | null>((resolve) => {
+            const reader = new FileReader()
+            reader.onload = () => {
+                const result = reader.result as string
+                _cache.set(path, result)
+                resolve(result)
+            }
+            reader.onerror = () => resolve(null)
+            reader.readAsDataURL(blob)
+        })
+    } catch {
+        return null
+    }
+}
+
+type MuscleEntry = { ratio?: number; sets?: number }
+
+export async function fetchMuscleMapAssets(
+    gender: 'male' | 'female' | 'not_informed',
+    muscleData: Record<string, unknown> | null | undefined,
+): Promise<MuscleMapAssets> {
+    const isFemale = gender === 'female'
+    const baseFrontPath = isFemale ? '/body-front-female.png' : '/body-front.png'
+    const baseBackPath = isFemale ? '/body-back-female.png' : '/body-back.png'
+    const maskFrontPath = isFemale ? '/body-front-female-mask.png' : '/body-front-mask.png'
+    const maskBackPath = isFemale ? '/body-back-female-mask.png' : '/body-back-mask.png'
+
+    const muscles = muscleData && typeof muscleData === 'object' && muscleData.muscles && typeof muscleData.muscles === 'object'
+        ? (muscleData.muscles as Record<string, MuscleEntry>)
+        : {}
+
+    const overlayFilesNeeded = new Set<string>()
+    Object.entries(FRONT_OVERLAY_BY_MUSCLE).forEach(([id, file]) => {
+        if (Number(muscles[id]?.ratio || 0) > 0) overlayFilesNeeded.add(file)
+    })
+    Object.entries(BACK_OVERLAY_BY_MUSCLE).forEach(([id, file]) => {
+        if (Number(muscles[id]?.ratio || 0) > 0) overlayFilesNeeded.add(file)
+    })
+
+    const [baseFront, baseBack, maskFront, maskBack] = await Promise.all([
+        fetchAsDataUrl(baseFrontPath),
+        fetchAsDataUrl(baseBackPath),
+        fetchAsDataUrl(maskFrontPath),
+        fetchAsDataUrl(maskBackPath),
+    ])
+
+    const overlayEntries = await Promise.all(
+        Array.from(overlayFilesNeeded).map(async (file) => {
+            const url = await fetchAsDataUrl(`/muscle-overlays/${file}`)
+            return [file, url] as const
+        }),
+    )
+
+    const overlays: Record<string, string> = {}
+    for (const [file, url] of overlayEntries) {
+        if (url) overlays[file] = url
+    }
+
+    return { baseFront, baseBack, maskFront, maskBack, overlays }
+}


### PR DESCRIPTION
## Problema

No PDF/HTML exportado, a seção "Mapa Muscular — Sua semana" estava aparecendo só como **caixas pretas** — sem silhueta, sem músculos. O HTML é renderizado em contextos isolados (iOS share sheet, file:// blob, print preview) que não conseguem buscar `https://irontracks.com.br/body-front.png` e os overlays.

Mesmo problema (e mesma fix) que o `fetchLogoDataUrl` já resolveu pra logo do app.

## Solução

Pré-carregar todas as PNGs como base64 data URLs e embedar no HTML.

- `src/utils/report/fetchMuscleMapAssets.ts` (novo): busca base + mask + overlays só dos músculos com ratio > 0 (paylod típico ~50-200 KB em vez de ~1 MB).
- `buildMuscleMapHtml.ts`: aceita `assets` em `BuildOptions`, usa data URLs quando presentes, faz fallback pra origin URLs.
- `buildHtml.ts`: lê `opts.muscleMapAssets` e repassa.
- `WorkoutReport.tsx`: pré-carrega antes do `buildReportHTML`, passa via mesma options bag do logo.

A seção React in-page continua usando URLs diretas de `/public` — funciona sempre num browser tab normal.

## Test plan

- [ ] Salvar relatório como PDF/HTML → silhuetas aparecem coloridas (não pretas)
- [ ] Compartilhar via iOS share → mesmo
- [ ] Usuário sem dados na semana → seção fica oculta (sem regressão)
- [ ] Usuária `biologicalSex=female` → silhueta feminina
- [ ] Relatório in-page continua funcionando (não tocou no MuscleMapSection)

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_