### PR TITLE
fix(dashboard): tab Nutrição não fecha overlay ao trocar de aba (esconde VIP)

### DIFF
--- a/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
+++ b/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
@@ -730,7 +730,13 @@ function IronTracksApp({ initialUser, initialProfile, initialWorkouts }: { initi
                                     profileIncomplete={Boolean(profileIncomplete)}
                                     onOpenCompleteProfile={() => setView('profile')}
                                     view={view === 'assessments' ? 'assessments' : view === 'community' ? 'community' : view === 'vip' ? 'vip' : 'dashboard'}
-                                    onChangeView={(next: string) => setView(next)}
+                                    onChangeView={(next: string) => {
+                                        // Close the nutrition overlay before switching views — it's a
+                                        // full-screen overlay, so leaving it open would hide the tab the
+                                        // user just clicked AND keep the Nutrição indicator stuck on.
+                                        setNutritionOpen(false)
+                                        setView(next)
+                                    }}
                                     assessmentsContent={
                                         (user?.id || initialUserObj?.id) ? (
                                             <ErrorBoundary>


### PR DESCRIPTION
## Bugs reportados (mesma causa raiz)

A aba Nutrição abre um `NutritionOverlay` full-screen (estado `nutritionOpen` separado do `view`) que **não fecha sozinho** quando o usuário clica outra aba.

1. **Tab Nutrição fica amarela em todas as outras abas** — `nutritionActive={nutritionOpen}` continua `true` mesmo o usuário já estando em Treinos / Avaliações / Comunidade / VIP.
2. **"VIP não entra"** — entra sim (`setView('vip')` roda), mas o `NutritionOverlay` segue renderizado em cima escondendo o VipHub.

## Fix

`onChangeView` em `IronTracksAppClientImpl.tsx` agora fecha o overlay de nutrição antes de mudar a view. 1 linha de muda real, com comentário explicando o porquê.

## Test plan

- [ ] Clica TREINOS → Nutrição → Comunidade → indicador da Nutrição apaga, conteúdo da Comunidade aparece
- [ ] Clica Nutrição → VIP → VipHub aparece (não fica coberto)
- [ ] Clica Nutrição → Nutrição de novo → reabre normalmente
- [ ] Clica fora do botão (notificações, profile, etc) → comportamento existente preservado (esses não passam por `onChangeView`)

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_