### PR TITLE
fix(vip): rate limit do resumo semanal era gasto até por cache hits + erro cru na UI

### DIFF
--- a/src/app/api/vip/weekly-summary/route.ts
+++ b/src/app/api/vip/weekly-summary/route.ts
@@ -107,18 +107,25 @@ export async function GET() {
     return NextResponse.json({ ok: false, error: 'vip_required', upgradeRequired: true }, { status: 403 })
   }
 
-  const rl = await checkRateLimitAsync(`vip-weekly-summary:${user.id}`, 5, 3_600_000)
-  if (!rl.allowed) {
-    return NextResponse.json(
-      { ok: false, error: 'rate_limit_exceeded' },
-      { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
-    )
-  }
+  const rl_key = `vip-weekly-summary:${user.id}`
 
   try {
     const cacheKey = `vip:weekly-summary:${user.id}`
     const cached = await cacheGet<Record<string, unknown>>(cacheKey, (v) => (v && typeof v === 'object' ? (v as Record<string, unknown>) : null))
     if (cached) return NextResponse.json(cached)
+
+    // Cache miss: this request will actually call the AI. Now is the time to
+    // gate it on the rate limiter — checking BEFORE the cache lookup made
+    // every refresh (even cached ones) tick the 5/hour budget down, so users
+    // were getting 429s after a handful of clicks even when nothing reached
+    // Gemini.
+    const rl = await checkRateLimitAsync(rl_key, 5, 3_600_000)
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { ok: false, error: 'ai_rate_limited' },
+        { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
+      )
+    }
 
     const now = Date.now()
     const startIso = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString()

--- a/src/components/vip/VipWeeklySummaryCard.tsx
+++ b/src/components/vip/VipWeeklySummaryCard.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RefreshCw, Flame, Trophy, Activity, Moon } from 'lucide-react'
 import { getErrorMessage } from '@/utils/errorMessage'
+import { translateAiError } from '@/utils/ai/clientErrors'
 
 type WeeklySummary = {
   ok: boolean
@@ -32,7 +33,11 @@ export default function VipWeeklySummaryCard() {
       const json = (await res.json().catch((): null => null)) as WeeklySummary | null
       if (!json?.ok) {
         setData(null)
-        setError(String(json?.error || 'Falha ao carregar resumo semanal.'))
+        const raw = String(json?.error || '')
+        // Keep 'vip_required' raw so the upgrade-CTA branch in the JSX
+        // can detect it. Everything else goes through translateAiError to
+        // hide canonical codes like 'ai_rate_limited' / 'rate_limit_exceeded'.
+        setError(raw === 'vip_required' ? 'vip_required' : translateAiError(raw))
         return
       }
       setData(json)


### PR DESCRIPTION
## Bug

No card "Resumo Semanal — Últimos 7 dias" do dashboard VIP, aparecia o código bruto **`rate_limit_exceeded`** depois de poucos cliques no botão "Atualizar".

## Causa raiz (dois bugs combinados)

1. **Rate limit eaten by cache hits.** A rota `/api/vip/weekly-summary` checava o rate-limit (5/hora) ANTES do `cacheGet`. Cada clique no Atualizar gastava 1/5 mesmo quando a resposta vinha do cache de 2 min — então 5 cliques rápidos = bloqueado por uma hora, mesmo sem Gemini ser chamado uma vez.

2. **Raw error code na UI.** O `VipWeeklySummaryCard` mostrava `String(json?.error)` direto pra tela em vez de traduzir.

## Fix

- Reordenar: `cacheGet` primeiro, rate-limit só no caminho de cache miss (única hora que custa $$$ de IA).
- Trocar o code retornado pra `'ai_rate_limited'` canônico (consistente com PR #83).
- Componente passa o erro pelo `translateAiError`, preservando o branch `vip_required` que dispara o CTA de upgrade.

## Test plan

- [ ] Abrir dashboard VIP → cache miss → 1 chamada → cache armado por 2 min
- [ ] Clicar Atualizar 10 vezes em sequência (dentro de 2 min) → todas servidas do cache, contador NÃO incrementa
- [ ] Após 2 min, clicar Atualizar → cache miss → faz nova chamada
- [ ] Forçar 5 cache misses em <1h → 6ª chamada retorna mensagem amigável: "Muitas tentativas em sequência..."
- [ ] Erro `vip_required` (free tier) ainda renderiza o CTA "Ver planos"

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_