### PR TITLE
fix(vip): bumpar rate limit do resumo semanal pra 60/h + bypass pra admin/elite

### DIFF
--- a/src/app/api/vip/weekly-summary/route.ts
+++ b/src/app/api/vip/weekly-summary/route.ts
@@ -107,7 +107,11 @@ export async function GET() {
     return NextResponse.json({ ok: false, error: 'vip_required', upgradeRequired: true }, { status: 403 })
   }
 
-  const rl_key = `vip-weekly-summary:${user.id}`
+  // Admin / VIP Elite are exempt from the per-user rate limit. They're either
+  // staff or top-tier paying users — the limiter is meant to protect Gemini
+  // budget from accidental loops, not gate normal usage.
+  const tier = String(plan?.tier || '').toLowerCase()
+  const skipRateLimit = tier === 'vip_elite' || tier === 'admin'
 
   try {
     const cacheKey = `vip:weekly-summary:${user.id}`
@@ -116,15 +120,20 @@ export async function GET() {
 
     // Cache miss: this request will actually call the AI. Now is the time to
     // gate it on the rate limiter — checking BEFORE the cache lookup made
-    // every refresh (even cached ones) tick the 5/hour budget down, so users
-    // were getting 429s after a handful of clicks even when nothing reached
-    // Gemini.
-    const rl = await checkRateLimitAsync(rl_key, 5, 3_600_000)
-    if (!rl.allowed) {
-      return NextResponse.json(
-        { ok: false, error: 'ai_rate_limited' },
-        { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
-      )
+    // every refresh (even cached ones) tick the budget down, so users were
+    // getting 429s after a handful of clicks even when nothing reached Gemini.
+    //
+    // Limit raised from 5/hour to 60/hour: the cache TTL is 2 min, so a user
+    // hammering Refresh would still hit cache 99% of the time. The previous
+    // 5/h was too tight for a button users tap repeatedly.
+    if (!skipRateLimit) {
+      const rl = await checkRateLimitAsync(`vip-weekly-summary:${user.id}`, 60, 3_600_000)
+      if (!rl.allowed) {
+        return NextResponse.json(
+          { ok: false, error: 'ai_rate_limited' },
+          { status: 429, headers: { 'Retry-After': String(rl.retryAfterSeconds) } },
+        )
+      }
     }
 
     const now = Date.now()


### PR DESCRIPTION
## Por quê

Follow-up do #90. Aquele PR resolveu o bug de cache hits gastarem budget — mas quem já estava bloqueado na janela de 1h continua bloqueado até ela passar. Duas mudanças pra desbloquear vítimas existentes E evitar recorrência:

1. **Bumpar 5/h → 60/h.** Cache de 2min cobre 99% dos refreshes; 5/h era apertado demais pra um botão que VIP usa repetidamente.
2. **Bypass total pra admin / VIP Elite.** Top tier ou staff não devem ser limitados — o limiter é pra stop accidental loops, não pra gate uso normal.

**Efeito colateral útil:** quem está atualmente em 5/5 vai ser liberado no próximo Refresh imediatamente, porque o `checkRateLimitAsync` compara `count <= max` e agora `max = 60`.

## Test plan

- [ ] Usuário VIP Elite no card "Resumo Semanal" → Atualizar várias vezes → nunca dá rate-limit (bypass)
- [ ] Usuário VIP Pro/Start → Atualizar 60+ vezes em 1h forçando cache miss → 61ª chamada retorna mensagem amigável
- [ ] Usuário que tava em 5/5 antes do deploy → primeira tentativa pós-deploy passa

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_