### PR TITLE
fix(ai/coach): coach-chat agora puxa últimos 5 treinos do usuário (histórico no prompt)

### DIFF
--- a/src/app/api/ai/coach-chat/route.ts
+++ b/src/app/api/ai/coach-chat/route.ts
@@ -8,6 +8,7 @@ import { parseJsonBody } from '@/utils/zod'
 import { logInfo, logError } from '@/lib/logger'
 import { env } from '@/utils/env'
 import { safeGemini, handleGeminiError } from '@/utils/ai/handleGeminiError'
+import { fetchRecentWorkoutHistory } from '@/utils/ai/recentWorkoutHistory'
 
 export const dynamic = 'force-dynamic'
 
@@ -64,6 +65,13 @@ export async function POST(req: Request) {
     const messages = normalizeMessages(body.messages)
     const context = body.context ?? null
 
+    // Pull a compact summary of the user's last 5 workouts so the coach can
+    // answer questions about progression, weights, recent volume, etc.
+    // Without this, the chat had no access to the user's history and would
+    // tell them "I don't have your performance data" — even when the report
+    // shows everything. (Reported by user testing 2026-05-03.)
+    const recentHistory = await fetchRecentWorkoutHistory(supabase, userId, 5)
+
     const apiKey = env.gemini.apiKey
     if (!apiKey) {
       return NextResponse.json(
@@ -82,13 +90,16 @@ export async function POST(req: Request) {
       'Não invente números; use apenas o que o usuário forneceu.',
       'Quando o usuário pedir um treino, monte um treino completo com nome, exercícios, séries, repetições, descanso e método de cada exercício.',
       '',
-      'Contexto (pode ser null):',
+      'Histórico recente do usuário (últimos treinos com pesos/reps/volume — pode ser vazio):',
+      recentHistory ? JSON.stringify(recentHistory) : '[]',
+      '',
+      'Contexto adicional fornecido pelo cliente (pode ser null — geralmente o treino atual ou comparação):',
       JSON.stringify(context),
       '',
       'Conversa:',
       JSON.stringify(messages),
       '',
-      'Responda com o texto final do coach (sem markdown).',
+      'Responda com o texto final do coach (sem markdown). Se o usuário perguntar sobre desempenho/progressão, USE o histórico acima — não diga "não tenho dados" se o histórico estiver populado.',
     ].join('\n')
 
     const genAI = new GoogleGenerativeAI(apiKey)

--- a/src/utils/ai/recentWorkoutHistory.ts
+++ b/src/utils/ai/recentWorkoutHistory.ts
@@ -1,0 +1,138 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Builds a compact, AI-friendly summary of the user's last few completed
+ * workouts so coach-chat (and similar conversational endpoints) can answer
+ * questions about volume, progression, recent loads, etc. without the user
+ * having to paste numbers manually.
+ *
+ * Output is intentionally tight on tokens: per workout we only emit the
+ * exercise name, the heaviest set (weight × reps), the total set count and
+ * a rough volume in kg. That's enough for a coach to comment on
+ * progression / fatigue without ballooning the prompt.
+ *
+ * Returns `null` when the user has no logged workouts — caller should pass
+ * that through to the prompt as "histórico vazio" rather than fabricating.
+ */
+
+interface CompactExercise {
+    name: string
+    setsDone: number
+    topSet: { weight: number; reps: number } | null
+    volumeKg: number
+}
+
+interface CompactWorkout {
+    date: string
+    name: string
+    durationMin: number | null
+    exercises: CompactExercise[]
+}
+
+const safeJsonParse = (raw: string): unknown => {
+    try {
+        return JSON.parse(raw)
+    } catch {
+        return null
+    }
+}
+
+const parseNum = (v: unknown): number => {
+    const n = Number(String(v ?? '').replace(',', '.'))
+    return Number.isFinite(n) ? n : 0
+}
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+    !!v && typeof v === 'object' && !Array.isArray(v)
+
+const compactFromSession = (session: Record<string, unknown>, workoutName: string, workoutDate: string): CompactWorkout => {
+    const exercises = Array.isArray(session.exercises) ? (session.exercises as unknown[]) : []
+    const logs = isObj(session.logs) ? session.logs : {}
+    const durationSec = Number(session.totalTime) || 0
+    const durationMin = durationSec > 0 ? Math.round(durationSec / 60) : null
+
+    const compactExercises: CompactExercise[] = exercises.map((ex, exIdx) => {
+        const exObj = isObj(ex) ? ex : {}
+        const name = String(exObj.name || `Exercício ${exIdx + 1}`).trim()
+
+        // Walk all logs that belong to this exercise (key prefix `${exIdx}-`).
+        let setsDone = 0
+        let volumeKg = 0
+        let topSet: { weight: number; reps: number } | null = null
+        Object.entries(logs).forEach(([k, log]) => {
+            if (!isObj(log)) return
+            const parts = String(k).split('-')
+            if (Number(parts[0]) !== exIdx) return
+            const w = parseNum(log.weight)
+            const r = parseNum(log.reps)
+            const done = Boolean(log.done) || (w > 0 && r > 0)
+            if (!done) return
+            setsDone += 1
+            if (w > 0 && r > 0) {
+                volumeKg += w * r
+                if (!topSet || w > topSet.weight || (w === topSet.weight && r > topSet.reps)) {
+                    topSet = { weight: w, reps: r }
+                }
+            }
+        })
+
+        return {
+            name,
+            setsDone,
+            topSet,
+            volumeKg: Math.round(volumeKg),
+        }
+    }).filter((e) => e.setsDone > 0)
+
+    return {
+        date: workoutDate,
+        name: workoutName,
+        durationMin,
+        exercises: compactExercises,
+    }
+}
+
+/**
+ * Fetch a compact summary of the user's last `limit` completed workouts.
+ * Reads from the `workouts.notes` JSON column where the full session is
+ * persisted (same as post-workout-insights).
+ */
+export async function fetchRecentWorkoutHistory(
+    supabase: SupabaseClient,
+    userId: string,
+    limit = 5,
+): Promise<CompactWorkout[] | null> {
+    if (!userId) return null
+    try {
+        const { data: rows } = await supabase
+            .from('workouts')
+            .select('id, name, date, notes')
+            .eq('user_id', userId)
+            .eq('is_template', false)
+            .order('date', { ascending: false })
+            .limit(limit)
+
+        if (!Array.isArray(rows) || rows.length === 0) return null
+
+        const compact: CompactWorkout[] = []
+        for (const row of rows as unknown[]) {
+            const r: Record<string, unknown> = isObj(row) ? row : {}
+            const notes = r.notes
+            const session = (() => {
+                if (!notes) return null
+                if (typeof notes === 'object') return notes as Record<string, unknown>
+                const parsed = safeJsonParse(String(notes))
+                return isObj(parsed) ? parsed : null
+            })()
+            if (!session) continue
+            const name = String(r.name || session.workoutTitle || 'Treino').trim() || 'Treino'
+            const date = String(r.date || '').trim()
+            const c = compactFromSession(session, name, date)
+            if (c.exercises.length > 0) compact.push(c)
+        }
+
+        return compact.length > 0 ? compact : null
+    } catch {
+        return null
+    }
+}


### PR DESCRIPTION
## Bug

Iron Coach IA (chat do VIP Hub) respondia que "não há dados de desempenho registrados (cargas, séries, repetições) para NENHUM dos seus últimos treinos" — mesmo o relatório tendo todos os dados.

## Causa raiz

A rota `/api/ai/coach-chat` só usa o `context` que o cliente manda. O `CoachChatModal` envia `{ session, previousSession }` — mas isso é o relatório atual + anterior. Quando o usuário abre o chat do VIP Hub (sem estar num relatório), `session` é `undefined` → IA recebe contexto vazio → cega.

A rota nunca consultava o Supabase pra puxar histórico.

## Fix

Novo helper `fetchRecentWorkoutHistory(supabase, userId, 5)` em `src/utils/ai/recentWorkoutHistory.ts` que lê `workouts.notes` (mesma fonte que o `post-workout-insights` usa) e emite um resumo bem compacto por treino:
- `date`, `name`, `durationMin`
- por exercício: `setsDone`, `topSet { weight, reps }`, `volumeKg`

Tight em tokens, suficiente pra IA falar sobre progressão.

A rota `coach-chat` chama esse helper depois do auth e injeta no prompt como seção rotulada. Também adiciono instrução no prompt: "se o histórico estiver populado, USE — não diga 'não tenho dados'".

## Test plan

- [ ] Abrir chat do VIP sem estar em relatório → perguntar "Qual foi meu volume da última semana?" → IA responde com base nos últimos treinos
- [ ] Perguntar "Como estou no supino?" → IA cita o último top set + sets feitos
- [ ] Usuário sem treinos → seção `histórico` chega como `[]` → IA responde apropriadamente
- [ ] Não introduz `console.log` / regressão no `npm run scan:secrets`

## Out of scope (próximo PR)

- Cache do histórico per-user (cada turn refetch — OK por enquanto)
- Endpoint `vip-coach` (estrutura diferente, outro PR)

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_