### PR TITLE
fix(admin): esconder sino de notificações para teachers

### DIFF
--- a/src/app/api/devices/live-activity-token/route.ts
+++ b/src/app/api/devices/live-activity-token/route.ts
@@ -10,10 +10,19 @@
  * row instead of accumulating stale tokens.
  */
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 import { createClient } from '@/utils/supabase/server'
 import { createAdminClient } from '@/utils/supabase/admin'
+import { parseJsonBody } from '@/utils/zod'
 
 const norm = (v: unknown) => String(v ?? '').trim()
+
+const BodySchema = z.object({
+  token: z.string().optional(),
+  kind: z.string().optional(),
+  activityId: z.string().optional(),
+  platform: z.string().optional(),
+}).passthrough()
 
 export async function POST(request: Request) {
   try {
@@ -23,8 +32,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 })
     }
 
-    let body: Record<string, unknown> = {}
-    try { body = await request.json() } catch { /* empty */ }
+    const parsed = await parseJsonBody(request, BodySchema)
+    const body = parsed.data ?? {}
 
     const token = norm(body?.token)
     const kind = norm(body?.kind) // 'rest' | 'workout' | …

--- a/src/app/api/push/live-activity-test/route.ts
+++ b/src/app/api/push/live-activity-test/route.ts
@@ -9,8 +9,15 @@
  * Response: { ok: boolean, results?: Array<{ token, ok, error? }> }
  */
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 import { createClient } from '@/utils/supabase/server'
 import { sendLiveActivityUpdate } from '@/lib/push/apnsLiveActivity'
+import { parseJsonBody } from '@/utils/zod'
+
+const BodySchema = z.object({
+  kind: z.string().optional(),
+  event: z.string().optional(),
+}).passthrough()
 
 export async function POST(request: Request) {
   try {
@@ -20,8 +27,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 })
     }
 
-    let body: Record<string, unknown> = {}
-    try { body = await request.json() } catch { /* empty */ }
+    const parsed = await parseJsonBody(request, BodySchema)
+    const body = parsed.data ?? {}
     const kindStr = String(body?.kind ?? 'workout').toLowerCase()
     const eventStr = String(body?.event ?? 'update').toLowerCase()
 

--- a/src/app/api/webhooks/whatsapp/route.ts
+++ b/src/app/api/webhooks/whatsapp/route.ts
@@ -7,14 +7,20 @@
  * Configure this URL in the Z-API dashboard under "On Message Received".
  */
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 import { createAdminClient } from '@/utils/supabase/admin'
 import { logError, logInfo, logWarn } from '@/lib/logger'
 import { sendWhatsAppText } from '@/lib/whatsapp/zapi'
 import { generateReply, fetchUserContext } from '@/lib/whatsapp/conversation'
 import type { ConversationTurn } from '@/lib/whatsapp/conversation'
 import { env } from '@/utils/env'
+import { parseJsonBody } from '@/utils/zod'
 
 export const dynamic = 'force-dynamic'
+
+// Z-API webhook payload é amplo e varia por evento — usamos passthrough
+// pra preservar todas as keys e validamos os campos relevantes inline.
+const ZapiBodySchema = z.object({}).passthrough()
 
 /**
  * Constant-time string comparison so we don't leak length/timing info to a
@@ -66,7 +72,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 })
     }
 
-    const body = await req.json() as Record<string, unknown>
+    const parsed = await parseJsonBody(req, ZapiBodySchema)
+    const body = (parsed.data ?? {}) as Record<string, unknown>
 
     // Ignore messages we sent ourselves, group messages, or empty payloads
     if (Boolean(body.fromMe) || Boolean(body.isGroup)) return NextResponse.json({ ok: true })

--- a/src/components/AdminPanelV2.tsx
+++ b/src/components/AdminPanelV2.tsx
@@ -170,6 +170,7 @@ const AdminPanelV2 = ({ user, onClose }: AdminPanelV2Props) => {
                     setTab={setTab}
                     setSelectedStudent={(value) => setSelectedStudent(value as AdminUser | null)}
                     onClose={onClose}
+                    isAdmin={isAdmin}
                 />
                 {/* Conteúdo scrollable. pb-32 deixa espaço pro bottom tab
                     bar (que tem ~72px de altura incluindo safe area).

--- a/src/components/admin-panel/AdminPanelHeader.tsx
+++ b/src/components/admin-panel/AdminPanelHeader.tsx
@@ -28,6 +28,9 @@ type AdminPanelHeaderProps = {
   setTab: (value: string) => void
   setSelectedStudent: (value: unknown) => void
   onClose?: () => void
+  /** Quando true, exibe o sino de notificações admin. Teachers não veem
+   *  (a API /api/admin/notifications/list retorna 403 pra non-admins). */
+  isAdmin?: boolean
 }
 
 export const AdminPanelHeader = ({
@@ -36,6 +39,7 @@ export const AdminPanelHeader = ({
   setTab,
   setSelectedStudent,
   onClose,
+  isAdmin = false,
 }: AdminPanelHeaderProps) => {
   // Quando admin clica numa notificação com link tipo "/admin?tab=requests",
   // extrai a tab e navega via setTab — evita full page reload.
@@ -91,7 +95,7 @@ export const AdminPanelHeader = ({
             <span className="hidden sm:inline text-[10px] font-bold uppercase tracking-widest text-neutral-500">
               {currentTabLabel}
             </span>
-            <AdminNotificationBell onNavigate={handleNotifNavigate} />
+            {isAdmin && <AdminNotificationBell onNavigate={handleNotifNavigate} />}
             <button
               onClick={() => onClose && onClose()}
               className="w-10 h-10 rounded-full bg-neutral-900/70 hover:bg-neutral-800 text-neutral-300 hover:text-white flex items-center justify-center transition-all border border-neutral-800 active:scale-95"


### PR DESCRIPTION
## Summary

**Fix principal:** sino `AdminNotificationBell` só renderiza para admins. Teachers compartilhavam o `AdminPanelHeader` e recebiam 403 a cada 60s no polling de `/api/admin/notifications/list`. Prop `isAdmin?: boolean` adicionada ao header e propagada do `AdminPanelV2`.

**Fix do CI (commit extra):** smoke test `no-direct-req-json` estava vermelho em `main` por 3 rotas que ainda usavam `await req.json()` direto. Migradas pro helper `parseJsonBody` com schemas Zod permissivos (`passthrough`), comportamento preservado:
- `/api/devices/live-activity-token`
- `/api/push/live-activity-test`
- `/api/webhooks/whatsapp`

## Test plan
- [x] `npx tsc --noEmit` zero erros
- [x] `eslint --max-warnings 0` nos arquivos editados
- [x] `npm run test:smoke` passa (incluindo `no-direct-req-json`)
- [ ] Logar como teacher (`teste@teste.com`) e confirmar que o sino sumiu
- [ ] Logar como admin e confirmar que o sino continua aparecendo
- [ ] Conferir Network tab — sem 403 pra `/api/admin/notifications/list` em sessão teacher
- [ ] Webhook Z-API e Live Activity continuam aceitando payloads como antes (passthrough preserva todas as keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)