### PR TITLE
fix(workout): modal do treino ativo pode panear lateralmente (cortando UI)

### DIFF
--- a/src/components/ActiveWorkout.tsx
+++ b/src/components/ActiveWorkout.tsx
@@ -181,12 +181,15 @@ export default function ActiveWorkout(props: ActiveWorkoutProps & { controlledBy
         initial={{ y: '100%' }}
         animate={{ y: isExiting ? '100%' : 0 }}
         transition={{ type: 'spring', damping: 30, stiffness: 300 }}
-        className="fixed inset-0 z-[50] flex flex-col bg-neutral-950 text-white"
+        className="fixed inset-0 z-[50] flex flex-col bg-neutral-950 text-white overflow-x-hidden"
       >
         <WorkoutHeader />
 
-        {/* Scrollable content — sits below the fixed header */}
-        <div className="flex-1 overflow-y-auto">
+        {/* Scrollable content — sits below the fixed header. overflow-x-hidden
+            here as belt + suspenders: even if some descendant (an exercise
+            card, the footer, a long copy line) overshoots the viewport width,
+            it gets clipped instead of letting the modal pan side-to-side. */}
+        <div className="flex-1 overflow-y-auto overflow-x-hidden">
           {/* Teacher control badge — subtle indicator when a teacher is controlling */}
           {props.controlledByName && (
             <div className="bg-indigo-500/10 border-b border-indigo-500/20 px-4 py-2 flex items-center gap-2 text-sm">


### PR DESCRIPTION
## Bug

Modal do treino ativo era mais largo que a tela em telas estreitas. O usuário conseguia "panear" lateralmente — partes da UI cortavam dos dois lados ("01" + ícone à esquerda; "1/24" + relógio + "AUTO" à direita).

## Fix

`fixed inset-0` no root do modal não tinha regra de `overflow-x`. Qualquer descendente que ultrapassasse a largura do viewport (uma carta de exercício com `min-w`, o footer em iPhones estreitos, um parágrafo longo de instrução) fazia o modal todo rolar lateralmente.

Adicionado `overflow-x-hidden` no root + no container scrollable como belt-and-suspenders. Clipping puro, sem custo de runtime.

## Test plan

- [ ] Abrir treino ativo em iPhone estreito (SE / Mini) → swipe lateral não move nada
- [ ] Exercício com nome muito longo ("Mesa flexora unilateral concentrada na máquina inclinada") → texto trunca/quebra, modal não pan
- [ ] Footer com START + AUTO + cronômetro → tudo cabe ou trunca, sem horizontal scroll
- [ ] Vertical scroll continua funcionando normalmente

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_