### PR TITLE
fix(workout): largura fixa no botão Feito + minmax(0,fr) no set row (corrige overflow real)

### DIFF
--- a/src/components/ActiveWorkout.tsx
+++ b/src/components/ActiveWorkout.tsx
@@ -181,12 +181,15 @@ export default function ActiveWorkout(props: ActiveWorkoutProps & { controlledBy
         initial={{ y: '100%' }}
         animate={{ y: isExiting ? '100%' : 0 }}
         transition={{ type: 'spring', damping: 30, stiffness: 300 }}
-        className="fixed inset-0 z-[50] flex flex-col bg-neutral-950 text-white"
+        className="fixed inset-0 z-[50] flex flex-col bg-neutral-950 text-white overflow-x-hidden"
       >
         <WorkoutHeader />
 
-        {/* Scrollable content — sits below the fixed header */}
-        <div className="flex-1 overflow-y-auto">
+        {/* Scrollable content — sits below the fixed header. overflow-x-hidden
+            here as belt + suspenders: even if some descendant (an exercise
+            card, the footer, a long copy line) overshoots the viewport width,
+            it gets clipped instead of letting the modal pan side-to-side. */}
+        <div className="flex-1 overflow-y-auto overflow-x-hidden">
           {/* Teacher control badge — subtle indicator when a teacher is controlling */}
           {props.controlledByName && (
             <div className="bg-indigo-500/10 border-b border-indigo-500/20 px-4 py-2 flex items-center gap-2 text-sm">

--- a/src/components/workout/set-renderers/normalSet.tsx
+++ b/src/components/workout/set-renderers/normalSet.tsx
@@ -374,7 +374,7 @@ const NormalSetInner = ({
           )}
         </div>
         {/* 4-column grid — no notes slot here; notes lives below both rows */}
-        <div className="grid items-center gap-1.5" style={{ gridTemplateColumns: '3fr 2fr 2fr auto' }}>
+        <div className="grid items-center gap-1.5 min-w-0" style={{ gridTemplateColumns: 'minmax(0,3fr) minmax(0,2fr) minmax(0,2fr) 76px' }}>
           {/* Weight */}
           <input
             inputMode="decimal"
@@ -415,7 +415,7 @@ const NormalSetInner = ({
           <button
             type="button"
             onClick={onComplete}
-            className={`inline-flex items-center justify-center gap-1 h-9 px-3 rounded-xl font-black text-xs whitespace-nowrap active:scale-95 transition-all duration-150 ${btnColor}`}
+            className={`inline-flex items-center justify-center gap-1 h-9 w-[76px] rounded-xl font-black text-xs whitespace-nowrap active:scale-95 transition-all duration-150 ${btnColor}`}
           >
             <Check size={13} />
             {sideDone ? '✓' : `${side} ✓`}
@@ -429,25 +429,25 @@ const NormalSetInner = ({
   // what each input means. After the first set, header is hidden to save space.
   const renderUnilateralHeader = () => (
     <div
-      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-400 font-bold"
-      style={{ gridTemplateColumns: '3fr 2fr 2fr auto' }}
+      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-400 font-bold min-w-0"
+      style={{ gridTemplateColumns: 'minmax(0,3fr) minmax(0,2fr) minmax(0,2fr) 76px' }}
     >
       <span>Peso (kg)</span>
       <span className="text-center">Reps</span>
       <span className="text-center">RPE</span>
-      <span className="w-14" />
+      <span />
     </div>
   );
   const renderBilateralHeader = () => (
     <div
-      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-400 font-bold"
-      style={{ gridTemplateColumns: '28px 3fr 2fr 2fr auto' }}
+      className="grid items-center gap-1.5 px-2.5 text-[9px] uppercase tracking-widest text-neutral-400 font-bold min-w-0"
+      style={{ gridTemplateColumns: '28px minmax(0,3fr) minmax(0,2fr) minmax(0,2fr) 76px' }}
     >
       <span />
       <span>Peso (kg)</span>
       <span className="text-center">Reps</span>
       <span className="text-center">RPE</span>
-      <span className="w-14" />
+      <span />
     </div>
   );
 
@@ -491,7 +491,7 @@ const NormalSetInner = ({
           {/* Order: 💬 | peso | reps | rpe | OK
               Notes is FIRST (left side) so it never aligns with footer buttons (DROP etc.) */}
           <div className="grid items-center gap-1.5"
-            style={{ gridTemplateColumns: '28px 3fr 2fr 2fr auto' }}>
+            style={{ gridTemplateColumns: '28px minmax(0,3fr) minmax(0,2fr) minmax(0,2fr) 76px' }}>
 
             {/* Notes toggle — leftmost, far from footer buttons */}
             <button
@@ -548,7 +548,7 @@ const NormalSetInner = ({
               type="button"
               onClick={handleComplete}
               className={[
-                'inline-flex items-center justify-center gap-1 h-9 px-3 rounded-xl font-black text-xs whitespace-nowrap active:scale-95 transition-all duration-150',
+                'inline-flex items-center justify-center gap-1 h-9 w-[76px] rounded-xl font-black text-xs whitespace-nowrap active:scale-95 transition-all duration-150',
                 done
                   ? 'bg-emerald-500 text-black shadow-sm shadow-emerald-500/30'
                   : 'bg-neutral-800 border border-neutral-700 text-neutral-200 hover:bg-neutral-700 hover:border-yellow-500/40',


### PR DESCRIPTION
## Bug (continuação do #97)

Mesmo depois do `overflow-x-hidden` do #97, o usuário relatou que o modal ainda ficava "grande" assim que a primeira série era marcada como Feito.

## Causa raiz real

O `overflow-x-hidden` estava CLIPANDO, mas o problema de fundo continuava: o `gridTemplateColumns: '3fr 2fr 2fr auto'` do set row usava o botão como coluna `auto`. Quando o texto mudava de "OK" (~50px) pra "Feito" (~85px), as colunas `fr` se recusavam a encolher (sem `minmax(0, ...)`) e o grid extrapolava o container. Em iOS Safari, o overflow-scroll elástico ainda permitia panear apesar do hidden.

## Fix

- **Botão de complete agora tem largura fixa `w-[76px]`** — cabe "OK" e "Feito"+check com folga, sem variação de tamanho ao mudar de estado.
- **Grid columns** trocaram `auto` no botão por `76px` fixo + `fr` → `minmax(0, Xfr)` nos inputs (peso/reps/RPE). Em telas estreitas as colunas encolhem agora em vez de empurrar a linha pra fora.
- Aplicado nas 4 grids em `normalSet.tsx` (unilateral row + header, bilateral row + header) e nos 2 botões de complete.

## Test plan

- [ ] Abrir treino ativo num iPhone estreito → marca 1 série como Feito → modal NÃO fica wider
- [ ] Trocar de série ainda "OK" pra Feito e voltar → largura do botão fica constante
- [ ] Telas largas (iPad/desktop) → inputs continuam grandes e aproveitam o espaço
- [ ] Cabeçalho da grid (Peso/Reps/RPE) continua alinhado com as células

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_