### PR TITLE
fix(persistence): treino ativo era perdido ao fechar app (regressão d779330)

### DIFF
--- a/src/hooks/useLocalPersistence.ts
+++ b/src/hooks/useLocalPersistence.ts
@@ -118,15 +118,22 @@ export function useLocalPersistence({
 
       return () => {
         clearTimeout(id)
-        // Cancela IDB timer no cleanup. Antes deixava completar pra preservar
-        // writes em fechamento de aba — mas isso podia persistir em conta errada
-        // quando o usuário trocava de userId. Trade-off: usuário pode perder até
-        // 2s de mudanças no fechamento abrupto; localStorage continua salvando
-        // a cada 250ms, então a perda é mínima.
-        if (idbTimerRef.current) {
-          clearTimeout(idbTimerRef.current)
-          idbTimerRef.current = null
-        }
+        // INTENCIONALMENTE NÃO cancela o idbTimer no cleanup.
+        //
+        // O cleanup roda quando o usuário fecha/backgrounda o app (regressão
+        // do commit d779330): se cancelássemos, a escrita debounced de 2s
+        // nunca completaria e a sessão ativa seria perdida no próximo
+        // launch. Foi exatamente o bug reportado em prod.
+        //
+        // E o cancel em re-run normal (mudança de activeSession) JÁ é feito
+        // na linha 112 (`clearTimeout(idbTimerRef.current)` antes do novo
+        // setTimeout). Então cleanup-cancel era redundante pra esse caminho
+        // E maléfico no caminho de unmount.
+        //
+        // A proteção "wrong user na troca de conta" — motivação original do
+        // d779330 — segue garantida pelo `capturedUserId` da closure: o
+        // callback persiste pro UID capturado no momento do agendamento,
+        // não pro UID atual.
       }
     } catch {
       return


### PR DESCRIPTION
## Bug crítico (urgência do usuário)

Usuário relatou em 2026-05-14:
> "Antes quando fechava o app com treino ativo e voltava, o treino estava ativo ainda, agora se sair e voltar perde o treino."

## Causa raiz

Regressão do commit `d779330`. Ele adicionou cancelamento do timer IDB no cleanup do `useEffect` em `useLocalPersistence.ts` ("pra evitar persistir em conta errada na troca de userId").

O cleanup do `useEffect`, porém, **também roda quando o componente desmonta** — o que acontece quando o usuário fecha/backgrounda o app no iOS. Resultado: o `setTimeout` de 2s que escreveria o estado pro IDB **era cancelado antes de completar**, e o relançamento do app não tinha onde ler.

## Fix

Remove o `clearTimeout(idbTimerRef.current)` do cleanup. A proteção "wrong user" continua garantida pelo `capturedUserId` (linha 113): mesmo se o `userId` mudar no meio do timer, o callback persiste pro UID capturado no momento de agendamento — nunca pro UID atual.

Em re-runs normais (mudança de `activeSession`) o timer antigo segue sendo cancelado na linha 112, antes de criar o novo. Então cleanup-cancel era redundante naquele caminho **e** maléfico no caminho de unmount.

O cleanup do localStorage debounce (250ms) fica — não é crítico de durabilidade.

## Test plan

- [ ] Iniciar treino → marcar 1 série → fechar app → reabrir → treino segue ativo
- [ ] Fechar app rapidamente (<2s após mudança) → relançar → mudança persiste (worst-case era um set perdido)
- [ ] Trocar de conta (signout + signin como outro user) → não restaura sessão da conta anterior

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_