### PR TITLE
fix(live-activity): mostrar descanso na Dynamic Island enquanto ativo (não o tempo total)

### DIFF
--- a/src/components/ActiveWorkout.tsx
+++ b/src/components/ActiveWorkout.tsx
@@ -43,6 +43,14 @@ export default function ActiveWorkout(props: ActiveWorkoutProps & { controlledBy
     exercises: exercises as unknown as ReadonlyArray<Record<string, unknown>>,
     logs: (session?.logs ?? {}) as Record<string, unknown>,
     currentExerciseIdx: controller.currentExerciseIdx ?? 0,
+    // While a rest countdown is active, end the workout Live Activity so the
+    // rest LA (started by RestTimerOverlay) owns the Dynamic Island slot.
+    // `session.timerTargetTime` is set when rest starts and cleared (null/0)
+    // when rest finishes or is dismissed — truthy = rest is on. We avoid
+    // comparing against Date.now() here because that's an impure call during
+    // render (react-hooks/purity); the cleared-on-dismiss flow covers the
+    // natural expiration case within ~500 ms.
+    restActive: Boolean((session as Record<string, unknown> | null)?.timerTargetTime),
   });
 
   // Exit animation — intercept back/finish callbacks to play slide-down before unmounting

--- a/src/hooks/useWorkoutLiveActivity.ts
+++ b/src/hooks/useWorkoutLiveActivity.ts
@@ -33,6 +33,11 @@ interface UseWorkoutLiveActivityArgs {
   logs: Record<string, unknown>
   /** Index of the exercise the user is currently focused on. */
   currentExerciseIdx: number
+  /** True while a rest countdown is active. While rest is on, the workout LA
+   *  is ended so the rest LA (started independently by RestTimerOverlay) is
+   *  the only Live Activity in the Dynamic Island. When rest ends, the
+   *  workout LA restarts automatically with the same `workoutStartMs`. */
+  restActive?: boolean
 }
 
 const isObj = (v: unknown): v is Record<string, unknown> =>
@@ -65,6 +70,7 @@ export function useWorkoutLiveActivity({
   exercises,
   logs,
   currentExerciseIdx,
+  restActive = false,
 }: UseWorkoutLiveActivityArgs): void {
   // ── Compute the current snapshot ──────────────────────────────────────────
   const snapshot = useMemo(() => {
@@ -115,11 +121,31 @@ export function useWorkoutLiveActivity({
   const pendingUpdateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Start exactly once when we have a valid start time. The hook callsite
-  // remounts when entering / leaving ActiveWorkout, so this is the right scope.
+  // remounts when entering / leaving ActiveWorkout, so this is the right
+  // scope. The `restActive` dep lets us pause/resume the workout LA so the
+  // rest countdown (started separately by RestTimerOverlay) is the only
+  // Live Activity shown in the Dynamic Island during rest — otherwise iOS
+  // picks one and it's usually the workout total, which the user perceived
+  // as "the rest timer isn't there".
   useEffect(() => {
     if (!isIosNative()) return
-    if (startedRef.current) return
     if (!Number.isFinite(workoutStartMs) || workoutStartMs <= 0) return
+
+    // During rest: hand the Dynamic Island slot over to the rest LA.
+    if (restActive) {
+      if (startedRef.current) {
+        if (pendingUpdateTimerRef.current) {
+          clearTimeout(pendingUpdateTimerRef.current)
+          pendingUpdateTimerRef.current = null
+        }
+        void endWorkoutLiveActivity()
+        startedRef.current = false
+      }
+      return
+    }
+
+    // Rest finished (or never started): make sure the workout LA is up.
+    if (startedRef.current) return
     startedRef.current = true
     void startWorkoutLiveActivity({
       workoutName,
@@ -134,10 +160,10 @@ export function useWorkoutLiveActivity({
       void endWorkoutLiveActivity()
       startedRef.current = false
     }
-    // We intentionally start with the FIRST snapshot — subsequent changes
-    // flow through the dedicated update effect below.
+    // Snapshot/workoutName changes flow through the dedicated update effect
+    // below — we only re-run this lifecycle for start/end transitions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workoutStartMs])
+  }, [workoutStartMs, restActive])
 
   // ── Throttled updates: max 1 per second ───────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Bug

Usuário relatou: na Dynamic Island, o timer mostra o tempo TOTAL do treino mesmo quando o descanso está rolando. O esperado é mostrar o countdown do descanso enquanto ele estiver ativo.

## Causa

`RestTimerOverlay` já abre uma Live Activity separada pro descanso, mas a LA do treino aberta pelo `useWorkoutLiveActivity` continua rodando em paralelo. iOS escolhe a do treino pro slot compacto da Dynamic Island, escondendo a do descanso.

## Fix

Novo prop `restActive` em `useWorkoutLiveActivity`. Quando true, encerra a workout LA. Quando volta a false (descanso dismissed/zerado), reinicia a workout LA com o mesmo `workoutStartMs` pra continuar o cronômetro total de onde parou.

`restActive` é derivado de `Boolean(session.timerTargetTime)` — setado quando descanso começa, limpo quando termina. Evita comparar `Date.now()` em render (react-hooks/purity); o auto-dismiss da rest overlay cobre a expiração natural em ~500 ms.

## Test plan

- [ ] Iniciar treino → Dynamic Island mostra tempo total contando
- [ ] Marcar série como Feito → rest overlay começa → Dynamic Island vira o countdown de descanso
- [ ] Descanso termina (auto ou tap) → Dynamic Island volta pro tempo total do treino
- [ ] Tempo total não pula (não reinicia de 0) ao voltar do descanso

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_