### PR TITLE
fix(workout): rest overlay também escapa lateralmente com nome de exercício longo

### DIFF
--- a/src/components/workout/RestTimerOverlay.tsx
+++ b/src/components/workout/RestTimerOverlay.tsx
@@ -516,7 +516,7 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
             {isFinished && !isTransition && (
                 <div
                     role="presentation"
-                    className={`fixed inset-0 z-[2000] backdrop-blur-sm flex flex-col items-center justify-center px-6 ${isSideRest ? 'bg-blue-600/90' : 'bg-green-600/90'}`}
+                    className={`fixed inset-0 z-[2000] backdrop-blur-sm flex flex-col items-center justify-center px-6 overflow-x-hidden ${isSideRest ? 'bg-blue-600/90' : 'bg-green-600/90'}`}
                     onClick={(e) => e.stopPropagation()}
                     onPointerDown={(e) => e.stopPropagation()}
                     onTouchStart={(e) => e.stopPropagation()}
@@ -528,7 +528,7 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                     ) : context?.nextSetLabel ? (
                         <>
                             <p className="text-white/70 font-bold mt-2 text-sm uppercase tracking-widest">Próxima</p>
-                            <p className="text-white font-black mt-1 text-2xl text-center leading-tight">{context.nextSetLabel}</p>
+                            <p className="text-white font-black mt-1 text-2xl text-center leading-tight max-w-full break-words px-2">{context.nextSetLabel}</p>
                         </>
                     ) : (
                         <p className="text-white/80 font-bold mt-2 text-lg">{finishedLabel}</p>
@@ -536,8 +536,8 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                 </div>
             )}
 
-            <div className="fixed bottom-0 left-0 right-0 bg-neutral-950/97 backdrop-blur-xl border-t border-neutral-800/80 py-2 px-4 shadow-2xl z-[2100] animate-slide-up pb-safe">
-                <div className="flex items-center gap-3 max-w-md mx-auto">
+            <div className="fixed bottom-0 left-0 right-0 bg-neutral-950/97 backdrop-blur-xl border-t border-neutral-800/80 py-2 px-4 shadow-2xl z-[2100] animate-slide-up pb-safe overflow-x-hidden">
+                <div className="flex items-center gap-3 max-w-md mx-auto min-w-0">
                     {/* Circular SVG ring — compact size matching bar height */}
                     <div className="relative flex-shrink-0" style={{ width: 68, height: 68 }}>
                         <svg width="68" height="68" viewBox="0 0 96 96" style={{ transform: 'rotate(-90deg)' }}>


### PR DESCRIPTION
## Bug

Usuário relatou que o **rest overlay** (tela "BORA!" durante descanso) também escapa horizontalmente. Print mostrava o texto "4ª série de Panturrilha no leg press horizontal" extrapolando a direita e o botão AUTO da barra inferior cortando.

#97/#98 corrigiram só o modal do treino ativo — esse é um overlay separado em `fixed inset-0 z-[2000]` que estava com o mesmo padrão de bug.

## Causa

1. O `<p>` com o `nextSetLabel` num `flex flex-col items-center` sem constraint de largura: em flex column o filho é sized to content, então uma frase longa cresce além do viewport e `items-center` centraliza algo já maior que o container.
2. Os roots `fixed` (BORA flash + barra inferior) sem `overflow-x-hidden` — qualquer overshoot dispara o elastic scroll horizontal do iOS Safari.

## Fix

- `<p>`: `max-w-full break-words px-2` (frase longa quebra, palavra ridícula quebra)
- BORA flash root: `overflow-x-hidden`
- Barra inferior: `overflow-x-hidden` + `min-w-0` no flex interno pra deixar os filhos encolherem

## Test plan

- [ ] Exercício com nome longo (ex: "Panturrilha no leg press horizontal") → BORA mostra duas linhas dentro da tela
- [ ] iPhone SE/Mini (mais estreito) → AUTO + START + timer cabem na barra
- [ ] Texto curto (ex: "Supino") → renderiza igual antes
- [ ] Modo TROCA (unilateral) e CHEGUEI (transição) sem regressão

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_