### PR TITLE
fix(dashboard): app inteiro fica wider que viewport (clip em 3 níveis)

### DIFF
--- a/src/app/(app)/dashboard/DashboardHeader.tsx
+++ b/src/app/(app)/dashboard/DashboardHeader.tsx
@@ -102,7 +102,7 @@ export function DashboardHeader({
 
     return (
         <>
-            <div className="bg-neutral-950 flex justify-between items-center fixed top-0 left-0 right-0 z-40 border-b border-zinc-800 px-6 shadow-lg pt-[env(safe-area-inset-top)] min-h-[calc(4rem+env(safe-area-inset-top))]">
+            <div className="bg-neutral-950 flex justify-between items-center fixed top-0 left-0 right-0 z-40 border-b border-zinc-800 px-6 shadow-lg pt-[env(safe-area-inset-top)] min-h-[calc(4rem+env(safe-area-inset-top))] overflow-x-hidden">
                 {/*
                   Logo + VIP badge container. Previously this whole block was a
                   single <button> wrapping the logo AND the VIP <button>, which

--- a/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
+++ b/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
@@ -912,7 +912,7 @@ function IronTracksApp({ initialUser, initialProfile, initialWorkouts }: { initi
                         {/* Main Content */}
                         <div
                             ref={mainScrollRef}
-                            className="flex-1 overflow-y-auto custom-scrollbar relative"
+                            className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar relative"
                             style={({
                                 ['--dashboard-sticky-top' as unknown as keyof React.CSSProperties]: isHeaderVisible
                                     ? 'calc(4rem + env(safe-area-inset-top))'

--- a/src/components/dashboard/StudentDashboard.tsx
+++ b/src/components/dashboard/StudentDashboard.tsx
@@ -265,7 +265,7 @@ export default function StudentDashboard(props: Props) {
   const vipLabel = String(props.vipLabel || 'VIP')
 
   return (
-    <div className={density === 'compact' ? 'p-4 space-y-3 pb-24' : 'p-4 space-y-4 pb-24'}>
+    <div className={density === 'compact' ? 'p-4 space-y-3 pb-24 overflow-x-hidden' : 'p-4 space-y-4 pb-24 overflow-x-hidden'}>
       {props.profileIncomplete && <ProfileIncompleteBanner settings={props.settings as import('@/schemas/settings').UserSettings | null} onComplete={props.onOpenCompleteProfile} />}
 
       <>


### PR DESCRIPTION
## Bug

Usuário reportou que o app inteiro fica wider que o viewport — tab VIP cortada na direita, foto de perfil clipada, "3.880kg v..." cortado, etc.

`html/body { overflow-x: hidden }` já existe em globals.css, e o root da page em `IronTracksAppClientImpl` tem `overflow-hidden`, mas algum descendente conseguia escapar no iOS WKWebView.

## Fix

Adiciona `overflow-x-hidden` em mais 3 níveis pra clipar onde quer que o overshoot esteja vindo:

1. **Inner scrollable area** (`flex-1 overflow-y-auto custom-scrollbar relative`) em `IronTracksAppClientImpl.tsx` — irmão direto do header fixed, faltava regra X.
2. **StudentDashboard root wrapper** (`p-4 space-y-3 pb-24`).
3. **DashboardHeader** (fixed top-0) — onde a foto de perfil tava clipando.

É estabilização de layout, não "esconde bug real" — se um componente filho tá com conteúdo wider que devia, agora ele trunca em vez de expandir a página.

## Test plan

- [ ] iPhone Mini/SE (mais estreito) → tab VIP visível por inteiro, foto de perfil cabe
- [ ] Conteúdos longos (nomes de exercício, números enormes) → truncam dentro do card
- [ ] Não introduz scrollbar horizontal nem em desktop nem mobile
- [ ] Scroll vertical da dashboard continua funcionando

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_