### PR TITLE
fix(header): avatar menu não abre — overflow-x-clip em vez de hidden

### DIFF
--- a/src/app/(app)/dashboard/DashboardHeader.tsx
+++ b/src/app/(app)/dashboard/DashboardHeader.tsx
@@ -102,7 +102,20 @@ export function DashboardHeader({
 
     return (
         <>
-            <div className="bg-neutral-950 flex justify-between items-center fixed top-0 left-0 right-0 z-40 border-b border-zinc-800 px-6 shadow-lg pt-[env(safe-area-inset-top)] min-h-[calc(4rem+env(safe-area-inset-top))] overflow-x-hidden">
+            {/*
+              overflow-x-clip (não -hidden): a spec CSS força overflow-y a se
+              tornar `auto` quando overflow-x é hidden/scroll/auto. Isso
+              CLIPAVA verticalmente o dropdown do HeaderActionsMenu (avatar
+              menu não abria visualmente — o state mudava, mas o painel
+              caía fora do container scrollável invisível do header).
+              overflow-x-clip clipa horizontalmente SEM criar scroll, então
+              overflow-y permanece visible e o dropdown escapa a base do
+              header normalmente. Suporte: iOS 16+, Chrome 90+, Firefox 81+
+              (em iOS 15 cai como `visible` graciosamente — sem clipping
+              mas funcional, e ninguém em prod ainda roda iOS 15 com
+              Capacitor 8).
+            */}
+            <div className="bg-neutral-950 flex justify-between items-center fixed top-0 left-0 right-0 z-40 border-b border-zinc-800 px-6 shadow-lg pt-[env(safe-area-inset-top)] min-h-[calc(4rem+env(safe-area-inset-top))] overflow-x-clip">
                 {/*
                   Logo + VIP badge container. Previously this whole block was a
                   single <button> wrapping the logo AND the VIP <button>, which


### PR DESCRIPTION
## Summary

Bug reportado em prod: usuário clica no avatar, **menu não abre**.

## Root cause

PR #102 (`dbaa80bb`) adicionou `overflow-x-hidden` no `<div>` fixed do header pra clipar overshoot horizontal no iOS WKWebView.

A spec CSS força **`overflow-y` a se tornar `auto`** quando `overflow-x` é `hidden`/`scroll`/`auto`. Resultado: o dropdown `position: absolute` do `HeaderActionsMenu` (que se estende abaixo do header via `mt-2`) era clipado verticalmente pelo container scrollável invisível do header — o state mudava (`open=true`) mas o painel ficava fora do viewport efetivo.

## Fix

Troca `overflow-x-hidden` por **`overflow-x-clip`**. O `clip` clipa horizontalmente SEM criar contexto de scroll, então `overflow-y` permanece `visible` (default) e o dropdown escapa a base do header normalmente.

**Suporte:** iOS 16+, Chrome 90+, Firefox 81+. Em iOS 15 degrada graciosamente pra `visible` (sem clipping, mas funcional). Capacitor 8 já exige iOS 13+ e ninguém em prod ainda roda iOS 15 com a stack atual.

## Test plan

- [ ] iOS (TestFlight build 38+): tap no avatar → dropdown abre normalmente
- [ ] Web (Chrome/Safari/Firefox): tap no avatar → dropdown abre normalmente
- [ ] Long-press no avatar → ainda abre story creator/viewer (não regredir o gesto que motivou o `relative`)
- [ ] Confirmar que o overshoot horizontal do header continua clipado (motivo original do PR #102)

## Não toca

Outros containers com mesmo padrão (`StudentDashboard`, `RestTimerOverlay`, `ActiveWorkout`) usam `overflow-x-hidden` sem `overflow-y` explícito — não hospedam dropdowns que se estendem além do container, mas se surgirem casos similares, abrir issue separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)