### PR TITLE
fix(persistence): flush síncrono de sessão ativa em background/pause

### DIFF
--- a/src/hooks/useLocalPersistence.ts
+++ b/src/hooks/useLocalPersistence.ts
@@ -12,6 +12,7 @@
 'use client'
 import { logWarn } from '@/lib/logger'
 import { persistActiveSession, clearPersistedSession } from '@/lib/offline/activeSessionPersistence'
+import { isIosNative, isAndroidNative } from '@/utils/platform'
 
 import { useEffect, useRef } from 'react'
 import type { ActiveWorkoutSession } from '@/types/app'
@@ -139,4 +140,82 @@ export function useLocalPersistence({
       return
     }
   }, [activeSession, userId])
+
+  // ─── Force flush on app pause / tab hidden / page hide ─────────────────────
+  //
+  // O PR #99 removeu o cancel do idbTimer no cleanup, mas isso só ajuda em
+  // unmounts NORMAIS (mudança de view, troca de conta). Em mobile, quando o
+  // iOS/Android suspende o WebView — usuário trocou de app, deu swipe-up no
+  // home, locked screen — o JS para de rodar imediatamente. Se o debounce de
+  // 250ms (localStorage) ou 2s (IDB) ainda não disparou, a sessão é PERDIDA.
+  //
+  // Fix: escutar lifecycle events e fazer flush SÍNCRONO do localStorage
+  // (sempre completa antes do kill) + best-effort IDB. Padrões cobertos:
+  //   • `visibilitychange` (hidden) — disparado pelo Safari/WKWebView em
+  //     background; mais confiável que pagehide no iOS.
+  //   • `pagehide` — fallback web (Chrome desktop, Firefox).
+  //   • Capacitor `App.appStateChange` — disparado pelo plugin nativo
+  //     antes do JS pausar; é o caminho mais cedo em iOS/Android nativo.
+  //
+  // O activeSession e userId são acessados via ref pra que o listener
+  // sempre veja o valor mais recente sem reagendar a cada mudança.
+  const activeSessionRef = useRef(activeSession)
+  const userIdRef = useRef(userId)
+  useEffect(() => { activeSessionRef.current = activeSession }, [activeSession])
+  useEffect(() => { userIdRef.current = userId }, [userId])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const flushImmediate = () => {
+      const s = activeSessionRef.current
+      const uid = userIdRef.current
+      if (!s || !uid) return
+      try {
+        const key = `irontracks.activeSession.v2.${uid}`
+        const payload = JSON.stringify({ ...(s as object), _savedAt: Date.now() })
+        localStorage.setItem(key, payload)
+      } catch (e) {
+        logWarn('useLocalPersistence.flush', 'localStorage flush failed', e)
+      }
+      // Best-effort IDB persist. Em iOS nativo isso dispara `nativeKvSet`
+      // via Capacitor bridge — pode ou não completar antes do kill, mas
+      // localStorage acima já garantiu o caminho síncrono.
+      persistActiveSession(uid, s as unknown as Record<string, unknown>).catch(() => {})
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushImmediate()
+    }
+    const onPageHide = () => flushImmediate()
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('pagehide', onPageHide)
+
+    // Capacitor App lifecycle — só carrega dinâmico em mobile pra não
+    // inflar o bundle web. `appStateChange` dispara com isActive=false
+    // ANTES do JS ser pausado pelo iOS, então é o caminho mais cedo.
+    let capListenerHandle: { remove: () => void } | null = null
+    let capListenerCancelled = false
+    if (isIosNative() || isAndroidNative()) {
+      import('@capacitor/app').then(({ App }) => {
+        if (capListenerCancelled) return
+        App.addListener('appStateChange', (state: { isActive?: boolean }) => {
+          if (!state?.isActive) flushImmediate()
+        })
+          .then((h) => {
+            if (capListenerCancelled) { h.remove(); return }
+            capListenerHandle = h
+          })
+          .catch((e) => logWarn('useLocalPersistence.flush', 'capacitor listener add failed', e))
+      }).catch((e) => logWarn('useLocalPersistence.flush', 'capacitor import failed', e))
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('pagehide', onPageHide)
+      capListenerCancelled = true
+      capListenerHandle?.remove()
+    }
+  }, [])
 }


### PR DESCRIPTION
## Summary

Bug em prod (relatado mesmo após PR #99): usuário inicia treino → fecha o app → reabre → **sessão perdida**, volta pro dashboard.

## Root cause

PR #99 (6e9b5d31) removeu o `clearTimeout(idbTimer)` no cleanup do `useEffect`, garantindo que o debounce de 2s do IDB complete em unmounts **normais** (mudança de view, troca de conta).

Mas isso não cobre o caso real do bug em mobile:

- Usuário em treino ativo abre outro app (ou swipe-up no home)
- iOS suspende o WKWebView **imediatamente** — JS para de rodar
- Se o `setTimeout(localStorage, 250)` ou `setTimeout(IDB, 2000)` ainda não disparou, **ambos são perdidos**
- Próximo launch: localStorage vazio → useSessionSync tenta IDB → também vazio → fallback pro server (que pode estar dessincronizado) → fallback final null → restore falha → sessão perdida

## Fix

Listener em 3 lifecycle events que fazem **flush imediato** quando o app vai pausar:

| Evento | Plataforma | Notas |
|--------|-----------|-------|
| `visibilitychange` (hidden) | Safari/WKWebView, Chrome | Mais confiável que pagehide no iOS |
| `pagehide` | Chrome desktop, Firefox | Fallback web |
| Capacitor `App.appStateChange` | iOS/Android nativo | Disparado **antes** do JS pausar; caminho mais cedo |

O flush:
1. **Síncrono**: `localStorage.setItem` — sempre completa antes do kill
2. **Best-effort**: `persistActiveSession` (IDB + native KV) — pode ou não completar

Mesmo que IDB falhe, o localStorage síncrono garante recuperação no próximo launch.

## Detalhes técnicos

- `activeSession` e `userId` acessados via `useRef` pra que o listener veja sempre o valor atual sem reagendar (o useEffect do listener roda só no mount).
- `@capacitor/app` carregado via `import()` dinâmico pra não inflar o bundle web.
- Compatível com PR #99: este fix ataca um caso ortogonal (app pause vs unmount normal).

## Test plan

- [ ] iOS Capacitor: iniciar treino → trocar pra outro app → voltar → treino restaurado
- [ ] iOS Capacitor: iniciar treino → swipe-up (home) → reabrir → treino restaurado
- [ ] iOS Capacitor: iniciar treino → travar tela → destravar → treino restaurado
- [ ] Web Safari: iniciar treino → fechar aba → reabrir → treino restaurado
- [ ] Web Chrome: idem
- [ ] Verificar logs: deve aparecer `persistActiveSession` chamado no `appStateChange`/`visibilitychange`

🤖 Generated with [Claude Code](https://claude.com/claude-code)