### PR TITLE
fix: 5 bugs latentes críticos (B-001..B-004 + B-007) do LATENT_BUGS.md

### DIFF
--- a/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
+++ b/src/app/(app)/dashboard/IronTracksAppClientImpl.tsx
@@ -1046,6 +1046,7 @@ function IronTracksApp({ initialUser, initialProfile, initialWorkouts }: { initi
                                         <CardioGPSPanel
                                             standalone
                                             onRequestClose={() => setStandaloneCardioOpen(false)}
+                                            userId={user?.id ? String(user.id) : null}
                                             bodyWeightKg={
                                                 typeof (userSettingsApi?.settings as Record<string, unknown> | null | undefined)?.bodyWeightKg === 'number'
                                                     ? (userSettingsApi?.settings as Record<string, unknown>).bodyWeightKg as number

--- a/src/components/ActiveWorkout.tsx
+++ b/src/components/ActiveWorkout.tsx
@@ -248,7 +248,10 @@ export default function ActiveWorkout(props: ActiveWorkoutProps & { controlledBy
           )}
 
           {/* GPS Cardio Tracking Panel */}
-          <CardioGPSPanel workoutId={props.session?.workout?.id} />
+          <CardioGPSPanel
+            workoutId={props.session?.workout?.id}
+            userId={String(props.settings?.userId ?? props.session?.userId ?? '') || null}
+          />
           <ExerciseList />
         </div>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -119,14 +119,24 @@ export default function SettingsModal(props: SettingsModalProps) {
   }, [isOpen])
 
   // ── iOS diagnostics ──────────────────────────────────────────────────────
+  // B-007: convertidos os `require()` síncronos em `import()` dinâmicos. Em
+  // arquivo "use client" (ESM), `require()` quebra silenciosamente em Next.js
+  // 16 + Turbopack — o try/catch externo engolia o erro e o painel iOS Diag
+  // SEMPRE aparecia vazio em prod, dando impressão de "feature quebrada em
+  // iOS" quando era só o bundler.
   const loadIosDiag = async () => {
     try {
       setIosDiagBusy(true)
-      const capCore = require('@capacitor/core')
-      const appMod = require('@capacitor/app')
-      const pushMod = require('@capacitor/push-notifications')
-      const deviceMod = require('@capacitor/device')
-      const Capacitor = capCore?.Capacitor
+      const [capCore, appMod, pushMod, deviceMod] = await Promise.all([
+        import('@capacitor/core').catch(() => null),
+        import('@capacitor/app').catch(() => null),
+        import('@capacitor/push-notifications').catch(() => null),
+        import('@capacitor/device').catch(() => null),
+      ])
+      // Capacitor typings expõem só `getPlatform`/`isNativePlatform`; o objeto
+      // `Plugins` é runtime-only. Cast pra interface ampliada pra ler sem
+      // perder type-safety do resto.
+      const Capacitor = capCore?.Capacitor as ({ getPlatform?: () => string; Plugins?: Record<string, unknown> } | undefined)
       const capacitorPresent = !!Capacitor
       const platform = String(Capacitor?.getPlatform?.() || 'unknown')
       const pluginNames = Capacitor?.Plugins ? Object.keys(Capacitor.Plugins) : []

--- a/src/components/dashboard/StudentDashboard.tsx
+++ b/src/components/dashboard/StudentDashboard.tsx
@@ -265,7 +265,11 @@ export default function StudentDashboard(props: Props) {
   const vipLabel = String(props.vipLabel || 'VIP')
 
   return (
-    <div className={density === 'compact' ? 'p-4 space-y-3 pb-24 overflow-x-hidden' : 'p-4 space-y-4 pb-24 overflow-x-hidden'}>
+    // B-004: overflow-x-clip em vez de -hidden — hidden força overflow-y a virar
+    // `auto` pela spec CSS, clipando o WorkoutToolsPanel (dropdown absolute right-0
+    // dentro do dashboard) verticalmente em iPhone SE / iPad split-view. Mesmo
+    // fix do PR #103 (avatar menu).
+    <div className={density === 'compact' ? 'p-4 space-y-3 pb-24 overflow-x-clip' : 'p-4 space-y-4 pb-24 overflow-x-clip'}>
       {props.profileIncomplete && <ProfileIncompleteBanner settings={props.settings as import('@/schemas/settings').UserSettings | null} onComplete={props.onOpenCompleteProfile} />}
 
       <>

--- a/src/components/workout/CardioGPSPanel.tsx
+++ b/src/components/workout/CardioGPSPanel.tsx
@@ -20,6 +20,11 @@ interface CardioGPSPanelProps {
   standalone?: boolean
   /** Called when user finishes the post-cardio flow in standalone mode */
   onRequestClose?: () => void
+  /**
+   * Owner user id. Enables IDB-backed crash recovery — without it,
+   * a kill mid-run still drops the GPS trail (legacy behavior).
+   */
+  userId?: string | null
 }
 
 // ─── Utils ────────────────────────────────────────────────────────────────────
@@ -272,6 +277,7 @@ export default function CardioGPSPanel({
   bodyWeightKg,
   standalone,
   onRequestClose,
+  userId,
 }: CardioGPSPanelProps) {
   const {
     isTracking,
@@ -286,7 +292,11 @@ export default function CardioGPSPanel({
     resume,
     stop,
     reset,
-  } = useCardioTracking({ bodyWeightKg })
+    recoveredCardio,
+    resumeRecoveredCardio,
+    discardRecoveredCardio,
+    finalizePersistedCardio,
+  } = useCardioTracking({ bodyWeightKg, userId })
   const [saving, setSaving] = useState(false)
   const [savedTrackId, setSavedTrackId] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -348,6 +358,9 @@ export default function CardioGPSPanel({
           paceMinKm: result.metrics.paceMinKm,
           caloriesEstimated: result.metrics.caloriesEstimated,
         })
+        // Server save succeeded — clear the IDB zombie so recovery on next
+        // mount doesn't offer to resume a run that already lives in the DB.
+        await finalizePersistedCardio()
         onSaved?.(data.track.id)
       } else {
         setSaveError('Não foi possível salvar a rota. Tente novamente.')
@@ -357,7 +370,7 @@ export default function CardioGPSPanel({
     } finally {
       setSaving(false)
     }
-  }, [stop, workoutId, onSaved, activityType])
+  }, [stop, workoutId, onSaved, activityType, finalizePersistedCardio])
 
   const handleReset = useCallback(() => {
     reset()
@@ -374,6 +387,31 @@ export default function CardioGPSPanel({
     isTracking && (gpsStatus === 'requesting-permission' || gpsStatus === 'acquiring' || !hasReliableFix)
   const startDisabled = gpsIsDenied || gpsIsUnavailable
   const signal = gpsSignalLabel(metrics.accuracyMeters)
+
+  // ── Recovery banner: only when we have persisted state AND no live run ─────
+  const recoveryBanner = recoveredCardio && !isTracking && !savedTrackId ? (
+    <div className="rounded-xl border border-yellow-500/30 bg-yellow-500/10 p-4 mb-3 flex flex-col gap-3">
+      <p className="text-sm text-yellow-100">
+        🏃 Você tem uma corrida em andamento. Retomar?
+      </p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => { void resumeRecoveredCardio() }}
+          className="px-3 py-1.5 rounded-lg bg-yellow-500 text-black font-semibold text-sm"
+        >
+          Retomar
+        </button>
+        <button
+          type="button"
+          onClick={() => { void discardRecoveredCardio() }}
+          className="px-3 py-1.5 rounded-lg bg-neutral-700 text-white text-sm"
+        >
+          Descartar
+        </button>
+      </div>
+    </div>
+  ) : null
 
   // ── Shared pieces ──────────────────────────────────────────────────────────
 
@@ -587,6 +625,7 @@ export default function CardioGPSPanel({
                 </span>
               </div>
             )}
+            {recoveryBanner}
             {gpsBanners}
             {gpsSignalBar}
             {activityTypeSelector}
@@ -608,6 +647,7 @@ export default function CardioGPSPanel({
   // ── Accordion content (inside a workout) — keep the old flat layout ────────
   const content = (
     <div className="px-4 pb-4">
+      {recoveryBanner}
       {gpsBanners}
       {gpsSignalBar}
       {activityTypeSelector}

--- a/src/components/workout/RestTimerOverlay.tsx
+++ b/src/components/workout/RestTimerOverlay.tsx
@@ -200,19 +200,25 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
             }
         };
         document.addEventListener('visibilitychange', onVisible);
+        // B-007: substituído `require('@capacitor/app')` síncrono por `import()`
+        // dinâmico. O require em arquivo "use client" (ESM) quebra silenciosamente
+        // no Next.js 16 + Turbopack — o try/catch engolia o erro e o listener
+        // appStateChange NUNCA registrava, deixando o alarm tocar indefinidamente
+        // quando user voltava do background. Dynamic import funciona em ambos os
+        // ambientes (CommonJS legacy e ESM moderno).
         let handle: { remove: () => void } | null = null;
-        try {
-            const appMod = require('@capacitor/app');
-            const App = appMod?.App;
-            if (App?.addListener) {
-                App.addListener('appStateChange', (state: { isActive?: boolean }) => {
-                    if (state?.isActive) stopAlarm(true);
-                }).then((h: { remove: () => void }) => {
-                    handle = h;
-                }).catch(() => { });
-            }
-        } catch { }
+        let cancelled = false;
+        import('@capacitor/app').then(({ App }) => {
+            if (cancelled || !App?.addListener) return;
+            App.addListener('appStateChange', (state: { isActive?: boolean }) => {
+                if (state?.isActive) stopAlarm(true);
+            }).then((h) => {
+                if (cancelled) { try { h.remove(); } catch { } return; }
+                handle = h;
+            }).catch(() => { });
+        }).catch(() => { });
         return () => {
+            cancelled = true;
             document.removeEventListener('visibilitychange', onVisible);
             if (handle) {
                 try { handle.remove(); } catch { }

--- a/src/hooks/useCardioTracking.ts
+++ b/src/hooks/useCardioTracking.ts
@@ -5,6 +5,13 @@ import { useGeoLocation, type GeoFix, type TrackingStatus } from './useGeoLocati
 import { totalTrackDistance, avgPaceMinKm, speedKmh, haversineDistance } from '@/utils/geoUtils'
 import type { GeoTrackPoint } from '@/utils/geoUtils'
 import { decideCardioFilter, estimateCardioCalories } from '@/utils/cardioFilters'
+import {
+  persistActiveCardio,
+  recoverActiveCardio,
+  clearPersistedCardio,
+} from '@/lib/offline/cardioPersistence'
+import { logWarn } from '@/lib/logger'
+import { isIosNative, isAndroidNative } from '@/utils/platform'
 
 interface CardioMetrics {
   /** Total distance in meters. */
@@ -42,6 +49,13 @@ interface UseCardioTrackingOptions {
    * running or trail-biking pace but far below car speeds. Default 45.
    */
   maxRealisticSpeedKmh?: number
+  /**
+   * Owner user id. When provided, the hook persists the live cardio state
+   * to IDB (debounced + lifecycle flush) so a crash/kill mid-run can be
+   * resumed. Without it, persistence is disabled and behavior is identical
+   * to the legacy in-memory hook.
+   */
+  userId?: string | null
 }
 
 interface UseCardioTrackingResult {
@@ -72,6 +86,18 @@ interface UseCardioTrackingResult {
     finishedAt: string
   } | null
   reset: () => void
+  /**
+   * Snapshot of a previously-persisted cardio session found on mount.
+   * Null when there's nothing to resume. The UI should show a "Retomar?"
+   * banner while this is set AND `isTracking` is false.
+   */
+  recoveredCardio: Record<string, unknown> | null
+  /** Restore the persisted state into the live hook and resume tracking. */
+  resumeRecoveredCardio: () => Promise<void>
+  /** Drop the persisted state and dismiss the banner. */
+  discardRecoveredCardio: () => Promise<void>
+  /** Force-clear the persisted cardio (e.g. after a successful server save). */
+  finalizePersistedCardio: () => Promise<void>
 }
 
 const EMPTY_METRICS: CardioMetrics = {
@@ -114,6 +140,7 @@ export function useCardioTracking({
   maxAccuracyMeters = 30,
   minMovementMeters = 5,
   maxRealisticSpeedKmh = 45,
+  userId = null,
 }: UseCardioTrackingOptions = {}): UseCardioTrackingResult {
   const {
     position,
@@ -286,6 +313,171 @@ export function useCardioTracking({
     latestFixRef.current = null
   }, [stopWatching])
 
+  // ── Persistence: dual-write to IDB so a kill mid-run doesn't lose data ──
+  //
+  // The cardio hook used to keep `trackPoints` + `metrics` in useState only,
+  // with a single server save at `stop()`. App killed mid-run (iOS suspend,
+  // low-memory kill, user swipes away) → 100% of the GPS trail gone. Now we
+  // mirror `useLocalPersistence`'s strategy: debounce-write while running,
+  // sync-flush on lifecycle pause, recover on next mount.
+
+  const [recoveredCardio, setRecoveredCardio] = useState<Record<string, unknown> | null>(null)
+
+  // Refs synced with state — used by the lifecycle flush listener that
+  // doesn't re-bind on every tick, and by the stop()/callbacks below.
+  const isTrackingRef = useRef(isTracking)
+  const metricsRef = useRef(metrics)
+  const userIdRef = useRef<string | null>(userId)
+  useEffect(() => { isTrackingRef.current = isTracking }, [isTracking])
+  useEffect(() => { metricsRef.current = metrics }, [metrics])
+  useEffect(() => { userIdRef.current = userId }, [userId])
+
+  // ── Recovery: check IDB on mount for a persisted run ───────────────────
+  useEffect(() => {
+    if (!userId) return
+    let cancelled = false
+    recoverActiveCardio(userId)
+      .then((state) => {
+        if (cancelled || !state) return
+        setRecoveredCardio(state)
+      })
+      .catch(() => { /* non-critical */ })
+    return () => { cancelled = true }
+  }, [userId])
+
+  // ── Debounced IDB write while cardio is active ─────────────────────────
+  //
+  // "Active" detection: `isTracking === true` AND we have a startTimeRef
+  // (i.e. start() was called and the clock is running). We persist even
+  // while paused — pause is a temporary halt, not "no cardio". Discarding
+  // paused state would lose a perfectly resumable run.
+  const idbDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (!userId) return
+    if (!isTracking) return
+    if (startTimeRef.current <= 0) return
+
+    if (idbDebounceRef.current) clearTimeout(idbDebounceRef.current)
+    const capturedUserId = userId
+    idbDebounceRef.current = setTimeout(() => {
+      persistActiveCardio(capturedUserId, {
+        trackPoints,
+        metrics,
+        startedAt: startTimeRef.current,
+        startedAtIso: startedAtRef.current,
+        pausedDurationMs: pausedDurationRef.current,
+        maxSpeedKmh: maxSpeedRef.current,
+        isPaused,
+        bodyWeightKg,
+      }).catch(() => { /* best effort */ })
+      idbDebounceRef.current = null
+    }, 5000)
+
+    // INTENCIONALMENTE NÃO cancela no cleanup — mesmo motivo do PR #99 em
+    // useLocalPersistence: cleanup roda quando app é backgroundado, e
+    // cancelar abortaria a escrita debounced. O re-run normal já chama
+    // clearTimeout antes do novo setTimeout acima.
+  }, [trackPoints, metrics, isTracking, isPaused, userId, bodyWeightKg])
+
+  // ── Lifecycle flush — visibilitychange / pagehide / Capacitor pause ─────
+  //
+  // Espelha o listener de useLocalPersistence: quando o iOS/Android
+  // suspende o WebView (user trocou de app, swipe-up, lock screen), o JS
+  // para de rodar e o debounce de 5s acima não chega a disparar.
+  // Aqui fazemos flush IMEDIATO (sem debounce) via persistActiveCardio.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const flushImmediate = () => {
+      const uid = userIdRef.current
+      if (!uid) return
+      if (!isTrackingRef.current) return
+      if (startTimeRef.current <= 0) return
+      const state: Record<string, unknown> = {
+        trackPoints: trackPointsRef.current,
+        metrics: metricsRef.current,
+        startedAt: startTimeRef.current,
+        startedAtIso: startedAtRef.current,
+        pausedDurationMs: pausedDurationRef.current,
+        maxSpeedKmh: maxSpeedRef.current,
+      }
+      persistActiveCardio(uid, state).catch(() => { /* best effort */ })
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushImmediate()
+    }
+    const onPageHide = () => flushImmediate()
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('pagehide', onPageHide)
+
+    // Capacitor App lifecycle — dynamic import so the web bundle stays slim
+    let capListenerHandle: { remove: () => void } | null = null
+    let capListenerCancelled = false
+    if (isIosNative() || isAndroidNative()) {
+      import('@capacitor/app').then(({ App }) => {
+        if (capListenerCancelled) return
+        App.addListener('appStateChange', (state: { isActive?: boolean }) => {
+          if (!state?.isActive) flushImmediate()
+        })
+          .then((h) => {
+            if (capListenerCancelled) { h.remove(); return }
+            capListenerHandle = h
+          })
+          .catch((e) => logWarn('useCardioTracking.flush', 'capacitor listener add failed', e))
+      }).catch((e) => logWarn('useCardioTracking.flush', 'capacitor import failed', e))
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('pagehide', onPageHide)
+      capListenerCancelled = true
+      capListenerHandle?.remove()
+    }
+  }, [])
+
+  // ── Recovery callbacks ─────────────────────────────────────────────────
+
+  const resumeRecoveredCardio = useCallback(async () => {
+    if (!recoveredCardio) return
+    const points = Array.isArray(recoveredCardio.trackPoints)
+      ? (recoveredCardio.trackPoints as GeoTrackPoint[])
+      : []
+    const startedAtMs = Number(recoveredCardio.startedAt || 0)
+    if (!startedAtMs) return
+
+    const recoveredMetrics = (recoveredCardio.metrics && typeof recoveredCardio.metrics === 'object')
+      ? (recoveredCardio.metrics as CardioMetrics)
+      : EMPTY_METRICS
+    const pausedDurationMs = Number(recoveredCardio.pausedDurationMs || 0)
+    const recoveredMaxSpeed = Number(recoveredCardio.maxSpeedKmh || 0)
+    const recoveredStartedAtIso = typeof recoveredCardio.startedAtIso === 'string'
+      ? recoveredCardio.startedAtIso
+      : new Date(startedAtMs).toISOString()
+
+    startTimeRef.current = startedAtMs
+    pausedDurationRef.current = pausedDurationMs
+    maxSpeedRef.current = recoveredMaxSpeed
+    startedAtRef.current = recoveredStartedAtIso
+
+    setTrackPoints(points)
+    setMetrics(recoveredMetrics)
+    setIsTracking(true)
+    setIsPaused(false)
+    setRecoveredCardio(null)
+    await startWatching()
+  }, [recoveredCardio, startWatching])
+
+  const discardRecoveredCardio = useCallback(async () => {
+    if (userId) await clearPersistedCardio(userId)
+    setRecoveredCardio(null)
+  }, [userId])
+
+  const finalizePersistedCardio = useCallback(async () => {
+    if (userId) await clearPersistedCardio(userId)
+  }, [userId])
+
   const hasReliableFix =
     !!position && position.accuracyMeters <= maxAccuracyMeters
 
@@ -302,5 +494,9 @@ export function useCardioTracking({
     resume,
     stop,
     reset,
+    recoveredCardio,
+    resumeRecoveredCardio,
+    discardRecoveredCardio,
+    finalizePersistedCardio,
   }
 }

--- a/src/hooks/useSessionSync.ts
+++ b/src/hooks/useSessionSync.ts
@@ -21,6 +21,7 @@ import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js'
 import type { ActiveWorkoutSession } from '@/types/app'
 import { logError, logWarn } from '@/lib/logger'
 import { recoverActiveSession } from '@/lib/offline/activeSessionPersistence'
+import { isIosNative, isAndroidNative } from '@/utils/platform'
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
     v !== null && typeof v === 'object' && !Array.isArray(v)
@@ -126,6 +127,12 @@ export function useSessionSync({
 }: UseSessionSyncParams) {
     const serverSessionSyncRef = useRef<{ timer: ReturnType<typeof setTimeout> | null; lastKey: string }>({ timer: null, lastKey: '' })
     const serverSessionSyncWarnedRef = useRef(false)
+    // Ref para o `run` atual do effect #3. Permite que o lifecycle listener
+    // (visibilitychange / pagehide / Capacitor appStateChange) dispare o
+    // upsert pendente IMEDIATAMENTE quando o app entra em background, antes
+    // do JS pausar. Sem isso, o debounce de 900ms é cancelado no cleanup e
+    // a última atualização do servidor é perdida (multi-device fica stale).
+    const pendingServerFlushRef = useRef<(() => Promise<void>) | null>(null)
     // Tracks whether local writes should be suppressed (when teacher is in control).
     // Used as a ref so changing this flag doesn't restart the effects.
     // Atualização do .current dentro de useEffect (não em render) — react-hooks/refs.
@@ -423,7 +430,17 @@ export function useSessionSync({
             serverSessionSyncRef.current.timer = timerId
         } catch { }
 
-        return () => { try { if (timerId) clearTimeout(timerId) } catch { } }
+        // Expõe o `run` atual para o flush lifecycle (effect abaixo). Cada
+        // re-run deste effect substitui o callback pelo `run` mais recente,
+        // que captura o `activeSession` correto via closure.
+        pendingServerFlushRef.current = run
+
+        return () => {
+            try { if (timerId) clearTimeout(timerId) } catch { }
+            // Não limpamos pendingServerFlushRef aqui — o próximo run do
+            // effect sobrescreve, e em unmount real (logout) o hook inteiro
+            // some junto.
+        }
     }, [activeSession, supabase, userId, inAppNotify, setActiveSession, setView, isMissingTable, notifyMigrationWarning])
 
     // 4. Session ticker (1s interval)
@@ -515,4 +532,92 @@ export function useSessionSync({
         window.addEventListener('beforeunload', handler)
         return () => window.removeEventListener('beforeunload', handler)
     }, [activeSession])
+
+    // 7. Force server flush on app pause / tab hidden / page hide
+    //
+    // O effect #3 já faz upsert debounced (900ms). Quando o usuário backgrounda
+    // o app (lock screen, swipe up, troca de app) dentro desses 900ms da
+    // última série, o cleanup cancela o timer e o servidor fica com estado
+    // velho — outro device do mesmo user puxa stale state.
+    //
+    // useLocalPersistence (PR #104) já cobre o caminho LOCAL (localStorage +
+    // IDB) com listeners equivalentes. Este effect espelha a estratégia pro
+    // servidor: dispara o `run()` pendente sincronamente assim que o app sair
+    // de foco, garantindo que o último estado chegue no Supabase.
+    //
+    // Padrões cobertos (mesmos do useLocalPersistence):
+    //   • `visibilitychange` (hidden) — iOS/Safari/WKWebView background.
+    //   • `pagehide` — fallback web (Chrome desktop, Firefox).
+    //   • Capacitor `App.appStateChange` — caminho mais cedo em iOS/Android.
+    //
+    // O upsert é best-effort: chamamos a função supabase normal (sem keepalive)
+    // porque o supabase-js já gerencia auth headers e o JS costuma ter alguns
+    // ms antes de pausar de fato. Se o request for cancelado, localStorage/IDB
+    // local já cobrem a sessão pra restore no próximo launch.
+    //
+    // suppressLocalWritesRef: quando true (professor controla aluno) NÃO
+    // disparamos flush — o professor é a fonte da verdade.
+    useEffect(() => {
+        if (typeof window === 'undefined') return
+
+        const flushImmediate = () => {
+            // Respeita controle do professor — student não deve sobrescrever
+            // edições do teacher mesmo no flush de background.
+            if (suppressLocalWritesRef.current) return
+
+            const pending = pendingServerFlushRef.current
+            if (!pending) return
+
+            // Cancela o debounce pendente pra evitar double-fire (o run vai
+            // ser chamado já-já síncrono mesmo).
+            try {
+                if (serverSessionSyncRef.current?.timer) {
+                    clearTimeout(serverSessionSyncRef.current.timer)
+                    serverSessionSyncRef.current.timer = null
+                }
+            } catch { }
+
+            // Dispara o upsert imediatamente. É async mas não dá pra await —
+            // o JS pode pausar a qualquer momento. Best-effort: supabase-js
+            // mantém o fetch em flight e o iOS dá ~5s de runtime no background
+            // antes do hard suspend, suficiente pro request curto completar
+            // na maioria dos casos. Erros vão pro logWarn dentro do próprio
+            // run() (catch interno).
+            try { void pending() } catch (e) { logError('hook:useSessionSync.flushImmediate', e) }
+        }
+
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') flushImmediate()
+        }
+        const onPageHide = () => flushImmediate()
+
+        document.addEventListener('visibilitychange', onVisibilityChange)
+        window.addEventListener('pagehide', onPageHide)
+
+        // Capacitor App lifecycle — só importa dinâmico em mobile nativo pra
+        // não inflar o bundle web. `appStateChange` com isActive=false dispara
+        // ANTES do JS ser pausado pelo iOS, então é o caminho mais cedo.
+        let capListenerHandle: { remove: () => void } | null = null
+        let capListenerCancelled = false
+        if (isIosNative() || isAndroidNative()) {
+            import('@capacitor/app').then(({ App }) => {
+                if (capListenerCancelled) return
+                App.addListener('appStateChange', (state: { isActive?: boolean }) => {
+                    if (!state?.isActive) flushImmediate()
+                })
+                    .then((h) => {
+                        if (capListenerCancelled) { h.remove(); return }
+                        capListenerHandle = h
+                    })
+                    .catch((e) => logWarn('useSessionSync.flush', 'capacitor listener add failed', e))
+            }).catch((e) => logWarn('useSessionSync.flush', 'capacitor import failed', e))
+        }
+
+        return () => {
+            document.removeEventListener('visibilitychange', onVisibilityChange)
+            window.removeEventListener('pagehide', onPageHide)
+            capListenerCancelled = true
+            capListenerHandle?.remove()
+        }
+    }, [])
 }

--- a/src/hooks/useTeacherControl.ts
+++ b/src/hooks/useTeacherControl.ts
@@ -15,7 +15,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SupabaseClient, RealtimeChannel } from '@supabase/supabase-js'
 import { logError, logWarn } from '@/lib/logger'
+import { isIosNative, isAndroidNative } from '@/utils/platform'
 import type { ActiveWorkoutSession } from '@/types/app'
+
+// Runtime feature check: fetch `keepalive` permite que o request continue mesmo
+// se a página for descarregada (suportado em iOS Safari/WKWebView 15+, Chrome,
+// Firefox modernos). Avaliado uma vez no module load — não muda em runtime.
+const FETCH_KEEPALIVE_SUPPORTED: boolean = (() => {
+  try {
+    return typeof Request !== 'undefined' && 'keepalive' in new Request('http://localhost/')
+  } catch {
+    return false
+  }
+})()
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   v !== null && typeof v === 'object' && !Array.isArray(v)
@@ -188,6 +200,108 @@ export function useTeacherControl(
   // Cleanup pending save on unmount
   useEffect(() => () => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+  }, [])
+
+  // ─── Force flush on app pause / tab hidden / page hide ─────────────────────
+  //
+  // Espelha a estratégia do useLocalPersistence (PR #104), mas pro lado do
+  // professor. O debounce de 800ms acima é cancelado no unmount — em mobile,
+  // quando o iOS/Android suspende o WebView (professor backgroundou app,
+  // bloqueou tela, trocou de app), o setTimeout pode ser perdido antes de
+  // disparar, e a última edição feita pelo professor NUNCA chega no banco.
+  // O aluno continua vendo o valor velho.
+  //
+  // Fix: escutar lifecycle events e disparar `flushSave` imediato. Como o
+  // endpoint é PATCH + Bearer auth header, `navigator.sendBeacon` não serve
+  // (só faz POST sem headers customizáveis). Usamos `fetch keepalive: true`
+  // como caminho primário — suportado em iOS WKWebView 15+ e permite que
+  // o request termine mesmo após o documento ser descarregado. Fallback é
+  // fetch normal (best-effort).
+  //
+  // Refs garantem que o listener leia os valores mais recentes sem
+  // reagendar a cada mudança.
+  const studentUserIdRef = useRef(studentUserId)
+  const getAuthHeadersRef = useRef(getAuthHeaders)
+  useEffect(() => { studentUserIdRef.current = studentUserId }, [studentUserId])
+  useEffect(() => { getAuthHeadersRef.current = getAuthHeaders }, [getAuthHeaders])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const flushImmediate = () => {
+      const state = sessionRef.current
+      const sid = studentUserIdRef.current
+      if (!state || !sid) return
+
+      // Cancela debounce pendente — não faz sentido disparar de novo em 800ms
+      // se o app pode estar morto até lá.
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current)
+        saveTimerRef.current = null
+      }
+
+      // Fire-and-forget. Não dá pra await aqui — o handler de lifecycle
+      // precisa retornar síncrono pra que o browser não pause antes do
+      // request ser enfileirado.
+      ;(async () => {
+        try {
+          const savedAt = Date.now()
+          const patchedState = { ...state, _deviceId: TEACHER_DEVICE_ID, _savedAt: savedAt }
+          const headers = await getAuthHeadersRef.current()
+          const init: RequestInit = {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', ...headers },
+            body: JSON.stringify({ state: patchedState }),
+          }
+          if (FETCH_KEEPALIVE_SUPPORTED) {
+            init.keepalive = true
+          }
+          // Fire e esquece — o request continua via keepalive mesmo se a
+          // página for descarregada. Erros aqui são best-effort.
+          fetch(`/api/teacher/student-session/${sid}`, init)
+            .then((res) => {
+              if (res.ok) lastTeacherSaveAtRef.current = savedAt
+            })
+            .catch(() => { /* page may already be gone */ })
+        } catch (e) {
+          logWarn('useTeacherControl.flushImmediate', 'flush failed', { error: String(e) })
+        }
+      })()
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushImmediate()
+    }
+    const onPageHide = () => flushImmediate()
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('pagehide', onPageHide)
+
+    // Capacitor App lifecycle — só carrega dinâmico em mobile pra não
+    // inflar o bundle web. `appStateChange` com isActive=false dispara
+    // ANTES do JS ser pausado pelo iOS, então é o caminho mais cedo.
+    let capListenerHandle: { remove: () => void } | null = null
+    let capListenerCancelled = false
+    if (isIosNative() || isAndroidNative()) {
+      import('@capacitor/app').then(({ App }) => {
+        if (capListenerCancelled) return
+        App.addListener('appStateChange', (state: { isActive?: boolean }) => {
+          if (!state?.isActive) flushImmediate()
+        })
+          .then((h) => {
+            if (capListenerCancelled) { h.remove(); return }
+            capListenerHandle = h
+          })
+          .catch((e) => logWarn('useTeacherControl.flush', 'capacitor listener add failed', { error: String(e) }))
+      }).catch((e) => logWarn('useTeacherControl.flush', 'capacitor import failed', { error: String(e) }))
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('pagehide', onPageHide)
+      capListenerCancelled = true
+      capListenerHandle?.remove()
+    }
   }, [])
 
   return { session, isLoading, isSaving, sessionEnded, patchState }

--- a/src/lib/offline/cardioPersistence.ts
+++ b/src/lib/offline/cardioPersistence.ts
@@ -1,0 +1,93 @@
+/**
+ * @module cardioPersistence
+ *
+ * IDB-backed persistence for the active cardio (GPS) session.
+ * Mirrors `activeSessionPersistence` but holds a different shape:
+ * `trackPoints` array + computed `metrics` + `startedAt` epoch.
+ *
+ * The cardio hook saves to the server only on `stop()`. Without this
+ * second layer, a kill mid-run (iOS suspends the WebView, user swipes
+ * the app away, low-memory crash) loses 100% of the GPS trail. With
+ * it, we flush every ~5s while running and on every lifecycle pause,
+ * so the worst-case loss is a handful of seconds — and the user gets
+ * a "Retomar corrida?" banner on next mount.
+ */
+
+import { kvGet, kvSet } from './idb'
+import { logWarn, logInfo } from '@/lib/logger'
+
+const CARDIO_KEY_PREFIX = 'active_cardio_v1_'
+const MAX_CARDIO_AGE_MS = 24 * 60 * 60 * 1000 // 24 hours — same as workout sessions
+
+/**
+ * Persist the active cardio state to IDB KV store.
+ * Called by the hook's 5s debounce while tracking is active, and by
+ * the lifecycle flush listeners on tab-hidden / app-pause.
+ */
+export async function persistActiveCardio(
+  userId: string,
+  state: Record<string, unknown>,
+): Promise<boolean> {
+  if (!userId) return false
+  try {
+    const key = `${CARDIO_KEY_PREFIX}${userId}`
+    const payload = { ...state, _idbSavedAt: Date.now() }
+    await kvSet(key, payload)
+    return true
+  } catch (e) {
+    logWarn('cardioPersistence', 'IDB persist failed (non-fatal)', e)
+    return false
+  }
+}
+
+/**
+ * Recover an active cardio session from IDB. Returns null if no
+ * session exists, the session is stale (>24h), required fields are
+ * missing, or IDB is unavailable.
+ *
+ * Validation: must have `trackPoints` as an array AND a truthy
+ * `startedAt`. A persisted state without points isn't worth resuming
+ * (the user never moved past idle), and without `startedAt` the
+ * duration math is broken.
+ */
+export async function recoverActiveCardio(
+  userId: string,
+): Promise<Record<string, unknown> | null> {
+  if (!userId) return null
+  try {
+    const key = `${CARDIO_KEY_PREFIX}${userId}`
+    const raw = await kvGet(key)
+    if (!raw || typeof raw !== 'object') return null
+
+    const state = raw as Record<string, unknown>
+    if (!Array.isArray(state.trackPoints)) return null
+    if (!state.startedAt) return null
+
+    // Auto-expire stale sessions
+    const savedAt = Number(state._idbSavedAt || 0)
+    if (savedAt > 0 && Date.now() - savedAt > MAX_CARDIO_AGE_MS) {
+      logInfo('cardioPersistence', 'Expired IDB cardio removed', { age: Date.now() - savedAt })
+      await clearPersistedCardio(userId)
+      return null
+    }
+
+    return state
+  } catch (e) {
+    logWarn('cardioPersistence', 'IDB recovery failed', e)
+    return null
+  }
+}
+
+/**
+ * Clear the persisted cardio from IDB.
+ * Call on explicit finish (after server save), discard, or sign-out.
+ */
+export async function clearPersistedCardio(userId: string): Promise<void> {
+  if (!userId) return
+  try {
+    const key = `${CARDIO_KEY_PREFIX}${userId}`
+    await kvSet(key, null)
+  } catch (e) {
+    logWarn('cardioPersistence', 'IDB clear failed', e)
+  }
+}


### PR DESCRIPTION
## Summary

Resolve os 5 findings 🔴 críticos do audit `LATENT_BUGS.md` (gerado hoje pelo agent após os fixes do dia: PR #103 avatar + PR #104 treino ativo).

5 commits separados, 1 PR:

| ID | Bug | Arquivos |
|----|-----|---------|
| **B-001** | Cardio GPS perde 100% dos pontos se app killed mid-run | `useCardioTracking`, `cardioPersistence` (novo), `CardioGPSPanel`, `ActiveWorkout`, `IronTracksAppClientImpl` |
| **B-002** | `useTeacherControl` perde última edição do prof se backgrounda em <800ms | `useTeacherControl` |
| **B-003** | `useSessionSync` server upsert (900ms) cancelado no cleanup | `useSessionSync` |
| **B-004** | `WorkoutToolsPanel` clippado por `overflow-x-hidden` (igual ao avatar do #103) | `StudentDashboard` |
| **B-007** | `require('@capacitor/app')` quebra silencioso em ESM → alarm não para + iOS diag vazio | `RestTimerOverlay`, `SettingsModal` |

## Pattern aplicado

B-001/B-002/B-003 todos seguem o pattern estabelecido no PR #104:

1. `useRef` pra ler estado atual no listener sem reagendar
2. `useEffect` mount-only registrando:
   - `document.visibilitychange` (hidden → flush)
   - `window.pagehide`
   - Capacitor `App.appStateChange` via dynamic import (só nativo)
3. Cleanup robusto com flag `capListenerCancelled` pra race do import

API do flush varia por caso:
- B-001: `persistActiveCardio` (IDB via Capacitor bridge)
- B-002: `fetch({ keepalive: true })` pra PATCH com Bearer auth
- B-003: supabase-js `.upsert()` direto (best-effort; localStorage cobre)

## Test plan

### Mobile (iOS Capacitor)

- [ ] **B-001**: iniciar corrida → 5min → swipe-up home → reabrir → banner "Você tem corrida em andamento. Retomar?" aparece → tap Retomar → trackPoints + metrics + tempo restaurados
- [ ] **B-001**: idem → tap Descartar → banner some → IDB limpo
- [ ] **B-002**: prof edita carga de série pelo modal de controle → home button em <800ms → reabrir → aluno tem carga atualizada
- [ ] **B-003**: completar série final → home em <900ms → login em outro device → última série aparece
- [ ] **B-004**: iPhone SE → tab Dashboard → "Ferramentas" → dropdown não corta vertical
- [ ] **B-007**: durante rest timer com alarm tocando → backgroundar app → voltar → alarm para
- [ ] **B-007**: Settings → "Diagnóstico iOS" → painel preenche com plataforma + plugins

### Web

- [ ] **B-004**: viewport narrow → dropdown ferramentas visível inteiro
- [ ] **B-007**: Settings → diag iOS mostra `capacitorPresent: false, platform: 'web'` sem crashar

## Notas

- Esforço total estimado no audit: **~1d**. Real: ~50min via 3 agents paralelos + 2 fixes manuais.
- TS + ESLint zero erros / warnings em todos os arquivos modificados.
- Versão Android não foi bumped neste PR (deixei `versionCode 7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)