### PR TITLE
fix: zerar bugs latentes restantes — 9 fixes médios + baixos do LATENT_BUGS.md

### DIFF
--- a/src/components/RealtimeNotificationBridge.ts
+++ b/src/components/RealtimeNotificationBridge.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { RealtimeChannel } from '@supabase/supabase-js'
+import { logWarn } from '@/lib/logger'
 
 interface RealtimeNotificationBridgeProps {
   userId: string | number | null
@@ -22,7 +23,8 @@ const RealtimeNotificationBridge = ({ userId, setNotification }: RealtimeNotific
     let supabase: ReturnType<typeof createClient>
     try {
       supabase = createClient()
-    } catch {
+    } catch (e) {
+      logWarn('RealtimeNotificationBridge', 'createClient failed', e)
       return
     }
     let channel: RealtimeChannel | null = null
@@ -82,12 +84,14 @@ const RealtimeNotificationBridge = ({ userId, setNotification }: RealtimeNotific
                   senderName: title,
                   type: rawType || 'broadcast',
                 })
-              } catch {
+              } catch (e) {
+                logWarn('RealtimeNotificationBridge', 'realtime payload parse', e)
                 return
               }
             })
             .subscribe()
-        } catch {
+        } catch (e) {
+          logWarn('RealtimeNotificationBridge', 'channel subscribe failed', e)
           return
         }
       })()
@@ -96,7 +100,8 @@ const RealtimeNotificationBridge = ({ userId, setNotification }: RealtimeNotific
       mounted = false
       try {
         if (channel) supabase.removeChannel(channel)
-      } catch {
+      } catch (e) {
+        logWarn('RealtimeNotificationBridge', 'channel unsubscribe failed', e)
         return
       }
     }

--- a/src/contexts/team/useTeamBroadcast.ts
+++ b/src/contexts/team/useTeamBroadcast.ts
@@ -408,13 +408,46 @@ export function useTeamBroadcast({
             )
             .subscribe()
 
-        // Polling fallback every 5s (catches anything postgres_changes missed)
+        // Polling fallback every 15s (catches anything postgres_changes missed)
         // R9#3: Reduced from 5s to 15s — N users × 5s poll = excessive DB queries
-        const poll = setInterval(loadPersistedMessages, 15_000)
+        // B-010: pausa o poll quando aba está em background (drenava quota Supabase).
+        // Ao voltar pra visible, dispara 1 load imediato pra recuperar mensagens novas.
+        let pollId: ReturnType<typeof setInterval> | null = null
+        const startPoll = () => {
+            if (pollId !== null) return
+            pollId = setInterval(loadPersistedMessages, 15_000)
+        }
+        const stopPoll = () => {
+            if (pollId !== null) {
+                clearInterval(pollId)
+                pollId = null
+            }
+        }
+        const onVisibilityChange = () => {
+            if (typeof document === 'undefined') return
+            if (document.hidden) {
+                stopPoll()
+            } else {
+                loadPersistedMessages()
+                startPoll()
+            }
+        }
+
+        if (typeof document === 'undefined' || !document.hidden) startPoll()
+        try {
+            if (typeof document !== 'undefined') {
+                document.addEventListener('visibilitychange', onVisibilityChange)
+            }
+        } catch { /* SSR guard */ }
 
         return () => {
             supabase.removeChannel(rtChannel)
-            clearInterval(poll)
+            stopPoll()
+            try {
+                if (typeof document !== 'undefined') {
+                    document.removeEventListener('visibilitychange', onVisibilityChange)
+                }
+            } catch { /* SSR guard */ }
         }
     }, [teamSession?.id, user?.id, supabase])
 

--- a/src/contexts/team/useTeamInvites.ts
+++ b/src/contexts/team/useTeamInvites.ts
@@ -259,20 +259,42 @@ export function useTeamInvites({
             .subscribe();
 
         const POLL_MS = 20_000;
-        const pollId = setInterval(() => {
-            try { refetchInvites(); } catch { }
-        }, POLL_MS);
+        // B-010: pausa o poll de 20s quando aba está em background (drenava quota Supabase).
+        // Integra com o handleVisibility existente (que já faz refetch ao retornar) pra
+        // não duplicar listener — pausa o interval em hidden e retoma em visible.
+        let pollId: ReturnType<typeof setInterval> | null = null;
+        const startPoll = () => {
+            if (pollId !== null) return;
+            pollId = setInterval(() => {
+                try { refetchInvites(); } catch { }
+            }, POLL_MS);
+        };
+        const stopPoll = () => {
+            if (pollId !== null) {
+                clearInterval(pollId);
+                pollId = null;
+            }
+        };
 
         const handleVisibility = () => {
             try {
-                if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+                if (typeof document === 'undefined') return;
+                if (document.visibilityState === 'visible') {
                     refetchInvites();
+                    startPoll();
+                } else {
+                    stopPoll();
                 }
             } catch { }
         };
         const handleFocus = () => {
             try { refetchInvites(); } catch { }
         };
+
+        // Inicia o poll só se já estivermos visíveis.
+        if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+            startPoll();
+        }
 
         try {
             if (typeof document !== 'undefined') document.addEventListener('visibilitychange', handleVisibility);
@@ -288,7 +310,7 @@ export function useTeamInvites({
             } catch {
                 return;
             }
-            try { clearInterval(pollId); } catch { }
+            stopPoll();
             try {
                 if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', handleVisibility);
             } catch { }
@@ -406,9 +428,40 @@ export function useTeamInvites({
                 .subscribe();
         } catch (e) { logError('useTeamInvites.subscribeAccepted', e) }
 
-        const pollId = setInterval(() => {
-            try { pollAccepted(); } catch { }
-        }, 20_000);
+        // B-010: pausa o poll de 20s quando aba está em background (drenava quota Supabase).
+        // Ao voltar pra visible, dispara 1 pollAccepted imediato pra recuperar invites
+        // aceitos durante o background sem esperar o próximo tick.
+        let pollId: ReturnType<typeof setInterval> | null = null;
+        const startPoll = () => {
+            if (pollId !== null) return;
+            pollId = setInterval(() => {
+                try { pollAccepted(); } catch { }
+            }, 20_000);
+        };
+        const stopPoll = () => {
+            if (pollId !== null) {
+                clearInterval(pollId);
+                pollId = null;
+            }
+        };
+        const onVisibilityChange = () => {
+            try {
+                if (typeof document === 'undefined' || !mounted) return;
+                if (document.hidden) {
+                    stopPoll();
+                } else {
+                    pollAccepted();
+                    startPoll();
+                }
+            } catch { }
+        };
+
+        if (typeof document === 'undefined' || !document.hidden) startPoll();
+        try {
+            if (typeof document !== 'undefined') {
+                document.addEventListener('visibilitychange', onVisibilityChange);
+            }
+        } catch { }
 
         try { pollAccepted(); } catch { }
 
@@ -417,7 +470,12 @@ export function useTeamInvites({
             try {
                 if (channel) supabase.removeChannel(channel);
             } catch { }
-            try { clearInterval(pollId); } catch { }
+            stopPoll();
+            try {
+                if (typeof document !== 'undefined') {
+                    document.removeEventListener('visibilitychange', onVisibilityChange);
+                }
+            } catch { }
         };
     }, [supabase, user?.id, teamSession?.id, soundOpts, seenAcceptedInviteIdsRef]);
 

--- a/src/contexts/team/useTeamPresence.ts
+++ b/src/contexts/team/useTeamPresence.ts
@@ -88,11 +88,16 @@ export function useTeamPresence({ user, supabase, teamSession, teamworkV2Enabled
     }, [supabase, teamSession?.id, teamworkV2Enabled, user?.id]);
 
     // Presence heartbeat
+    // B-009: pausa o heartbeat quando aba está em background (drenava quota Supabase
+    // sem benefício, pois ninguém vê o status). Ao voltar pra visible, faz upsert
+    // imediato pra atualizar last_seen e sinalizar pro server que o usuário voltou.
     useEffect(() => {
         if (!teamworkV2Enabled) return;
         if (!teamSession?.id) return;
         if (!user?.id) return;
         let cancelled = false;
+        let intervalId: ReturnType<typeof setInterval> | null = null;
+
         const upsert = async () => {
             try {
                 await supabase
@@ -104,14 +109,47 @@ export function useTeamPresence({ user, supabase, teamSession, teamworkV2Enabled
             } catch (e) { logWarn("useTeamPresence", "silenced", e)
             }
         };
-        const t = setInterval(() => {
+        const tick = () => {
             if (cancelled) return;
             upsert();
-        }, 15000);
+        };
+        const start = () => {
+            if (intervalId !== null) return;
+            intervalId = setInterval(tick, 15000);
+        };
+        const stop = () => {
+            if (intervalId !== null) {
+                clearInterval(intervalId);
+                intervalId = null;
+            }
+        };
+        const onVisibilityChange = () => {
+            if (typeof document === 'undefined' || cancelled) return;
+            if (document.hidden) {
+                stop();
+            } else {
+                upsert();
+                start();
+            }
+        };
+
+        // Disparo inicial + inicia interval só se já estivermos visíveis.
         upsert();
+        if (typeof document === 'undefined' || !document.hidden) start();
+        try {
+            if (typeof document !== 'undefined') {
+                document.addEventListener('visibilitychange', onVisibilityChange);
+            }
+        } catch { /* SSR guard */ }
+
         return () => {
             cancelled = true;
-            clearInterval(t);
+            stop();
+            try {
+                if (typeof document !== 'undefined') {
+                    document.removeEventListener('visibilitychange', onVisibilityChange);
+                }
+            } catch { /* SSR guard */ }
         };
     }, [presenceStatus, supabase, teamSession?.id, teamworkV2Enabled, user?.id]);
 

--- a/src/hooks/useAssessmentHistoryData.ts
+++ b/src/hooks/useAssessmentHistoryData.ts
@@ -6,7 +6,7 @@ import { createClient } from '@/utils/supabase/client'
 import { useAssessment } from '@/hooks/useAssessment'
 import { generateAssessmentPlanAi } from '@/actions/workout-actions'
 import { getErrorMessage } from '@/utils/errorMessage'
-import { logError } from '@/lib/logger'
+import { logError, logWarn } from '@/lib/logger'
 import { safePg, safePgLike } from '@/utils/safePgFilter'
 
 import {
@@ -159,7 +159,9 @@ export function useAssessmentHistoryData(studentId?: string) {
         setTimeout(() => {
           try {
             planAnchorRefs.current[id]?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          } catch {}
+          } catch (e) {
+            logWarn('useAssessmentHistoryData', 'scrollIntoView plan anchor failed', e)
+          }
         }, 50)
       } catch (e) {
         const id = String(assessment?.id || '')
@@ -190,7 +192,9 @@ export function useAssessmentHistoryData(studentId?: string) {
         setPlanModalAssessment(assessment)
         setPlanModalOpen(true)
         await handleGenerateAssessmentPlan(assessment, { openDetails: false })
-      } catch {}
+      } catch (e) {
+        logWarn('useAssessmentHistoryData', 'open assessment plan modal failed', e)
+      }
     },
     [handleGenerateAssessmentPlan],
   )
@@ -361,7 +365,9 @@ export function useAssessmentHistoryData(studentId?: string) {
             .lte('completed_at', toIso)
             .order('completed_at', { ascending: true })
           if (!wErr && Array.isArray(data)) rows.push(...data)
-        } catch {}
+        } catch (e) {
+          logWarn('useAssessmentHistoryData', 'fetch workouts by user_id (completed_at) failed', e)
+        }
 
         try {
           const { data, error: wErr } = await supabase
@@ -373,7 +379,9 @@ export function useAssessmentHistoryData(studentId?: string) {
             .lte('completed_at', toIso)
             .order('completed_at', { ascending: true })
           if (!wErr && Array.isArray(data)) rows.push(...data)
-        } catch {}
+        } catch (e) {
+          logWarn('useAssessmentHistoryData', 'fetch workouts by student_id (completed_at) failed', e)
+        }
 
         if (fromDay && toDay) {
           try {
@@ -386,7 +394,9 @@ export function useAssessmentHistoryData(studentId?: string) {
               .lte('date', toDay)
               .order('date', { ascending: true })
             if (!wErr && Array.isArray(data)) rows.push(...data)
-          } catch {}
+          } catch (e) {
+            logWarn('useAssessmentHistoryData', 'fetch workouts by user_id (date) failed', e)
+          }
 
           try {
             const { data, error: wErr } = await supabase
@@ -398,7 +408,9 @@ export function useAssessmentHistoryData(studentId?: string) {
               .lte('date', toDay)
               .order('date', { ascending: true })
             if (!wErr && Array.isArray(data)) rows.push(...data)
-          } catch {}
+          } catch (e) {
+            logWarn('useAssessmentHistoryData', 'fetch workouts by student_id (date) failed', e)
+          }
         }
 
         const byId = new Map<string, AssessmentRow>()
@@ -425,7 +437,9 @@ export function useAssessmentHistoryData(studentId?: string) {
                 const sum = exerciseDurations.reduce<number>((acc: number, v: unknown) => acc + (Number(v) || 0), 0)
                 if (Number.isFinite(sum) && sum > 0) rawSeconds = sum
               }
-            } catch {}
+            } catch (e) {
+              logWarn('useAssessmentHistoryData', 'parse exerciseDurations from notes failed', e)
+            }
           }
           if (!rawSeconds) return
           const seconds = Math.min(rawSeconds, MAX_SESSION_SECONDS)

--- a/src/hooks/useCheckins.ts
+++ b/src/hooks/useCheckins.ts
@@ -53,12 +53,11 @@ export const useCheckins = ({
 }: UseCheckinsParams): UseCheckinsReturn => {
   const [checkinsByKind, setCheckinsByKind] = useState<{ pre: AnyObj | null; post: AnyObj | null }>({ pre: null, post: null })
 
+  const id = workoutId ? String(workoutId) : ''
+  const hasActiveQuery = !!id && !!supabase
+
   useEffect(() => {
-    const id = workoutId ? String(workoutId) : ''
-    if (!id || !supabase) {
-      const timer = setTimeout(() => { setCheckinsByKind({ pre: null, post: null }) }, 0)
-      return () => { clearTimeout(timer) }
-    }
+    if (!hasActiveQuery) return
 
     const baseMs = toDateMs(sessionDate) ?? toDateMs(sessionCompletedAt) ?? Date.now()
     const validBaseMs = Number.isFinite(baseMs) ? baseMs : null
@@ -68,7 +67,7 @@ export const useCheckins = ({
     let cancelled = false
     ;(async () => {
       try {
-        const { data } = await supabase
+        const { data } = await supabase!
           .from('workout_checkins')
           .select('kind, energy, mood, soreness, notes, answers, created_at')
           .eq('workout_id', id)
@@ -90,7 +89,7 @@ export const useCheckins = ({
         // Secondary lookup: pre check-in may be linked to planned_workout_id
         if (!next.pre && originWorkoutId && targetUserId && windowStartIso && windowEndIso) {
           try {
-            const { data: preRow } = await supabase
+            const { data: preRow } = await supabase!
               .from('workout_checkins')
               .select('kind, energy, mood, soreness, notes, answers, created_at')
               .eq('user_id', targetUserId)
@@ -106,13 +105,22 @@ export const useCheckins = ({
         }
 
         setCheckinsByKind(next)
-      } catch {
+      } catch (e) {
+        logWarn('useCheckins', 'primary checkin lookup failed', e)
         if (!cancelled) setCheckinsByKind({ pre: null, post: null })
       }
     })()
 
     return () => { cancelled = true }
-  }, [workoutId, originWorkoutId, sessionDate, sessionCompletedAt, supabase, targetUserId])
+  }, [id, hasActiveQuery, originWorkoutId, sessionDate, sessionCompletedAt, supabase, targetUserId])
 
+  // Derived output: when there's no active query (workoutId falsy or supabase
+  // null) return empty state without touching React state. This avoids the
+  // setTimeout(0) + setState dance the previous version used to dodge the
+  // "no setState in effect" rule, and is also why this hook doesn't need
+  // to reset checkinsByKind on workoutId change — the gate happens here.
+  if (!hasActiveQuery) {
+    return { preCheckin: null, postCheckin: null }
+  }
   return { preCheckin: checkinsByKind.pre, postCheckin: checkinsByKind.post }
 }

--- a/src/hooks/useGymCheckin.ts
+++ b/src/hooks/useGymCheckin.ts
@@ -70,7 +70,7 @@ const wasAlreadyChecked = (gymId: string): boolean => {
 
 const markChecked = (gymId: string): void => {
   if (typeof window === 'undefined') return
-  try { window.localStorage.setItem(buildCheckinKey(gymId), '1') } catch {}
+  try { window.localStorage.setItem(buildCheckinKey(gymId), '1') } catch (e) { logWarn('useGymCheckin', 'localStorage setItem failed', e) }
 }
 
 export function useGymCheckin(

--- a/src/hooks/useLocalPersistence.ts
+++ b/src/hooks/useLocalPersistence.ts
@@ -52,10 +52,24 @@ export function useLocalPersistence({
   useEffect(() => {
     try {
       if (!userId) return
-      // Só atua se estamos na raiz /dashboard. Em sub-rotas (/dashboard/admin,
-      // /dashboard/history, etc), URL já indica onde user está — não interferir.
-      if (typeof window !== 'undefined' && window.location.pathname !== '/dashboard') {
-        return
+      // Atua na raiz /dashboard E em /dashboard/active/* (B-012):
+      //
+      // - /dashboard (root): caminho clássico após login/cold-launch.
+      // - /dashboard/active[/<sessionId>]: user crashou DENTRO do treino ativo
+      //   e Capacitor preservou a URL ao reabrir. Sem o restore, a sub-rota
+      //   tenta hidratar via sessionId da URL — que pode ser stale/órfão — e
+      //   o snapshot do localStorage fica intacto mas inacessível.
+      //
+      // Outras sub-rotas (/dashboard/admin, /dashboard/history, etc) continuam
+      // respeitando a URL pra evitar o loop original (PR#4a).
+      //
+      // Caso já estejamos em /dashboard/active, o setView('active') vira no-op
+      // (IronTracksAppClientImpl linha 164: `if (target === view) return`).
+      if (typeof window !== 'undefined') {
+        const path = window.location.pathname
+        const isDashboardRoot = path === '/dashboard' || path === '/dashboard/'
+        const isActiveRoute = path === '/dashboard/active' || path.startsWith('/dashboard/active/')
+        if (!isDashboardRoot && !isActiveRoute) return
       }
 
       const scopedSessionKey = `irontracks.activeSession.v2.${userId}`

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -115,14 +115,54 @@ export function useOfflineSync({ userId, settings }: UseOfflineSyncOptions = {})
   // always call the latest version without causing listener churn.
   }, []);
 
-  // Auto-flush every 15s if there are pending items
+  // Auto-flush every 15s if there are pending items.
+  // B-008: pausa o interval quando aba fica em background (drenava bateria + dados móveis).
+  // Ao retornar pra visible, dispara 1 flush imediato em vez de esperar próximo tick.
   useEffect(() => {
     if (!userId) return;
     if (!isOnline()) return;
     if ((syncState?.pending || 0) <= 0) return;
-    const t = setInterval(() => { runFlushQueue(); }, 15_000);
-    return () => clearInterval(t);
-  }, [runFlushQueue, syncState?.pending, userId]);
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const tick = () => { flushRef.current(); };
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(tick, 15_000);
+    };
+    const stop = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+    const onVisibilityChange = () => {
+      if (typeof document === 'undefined') return;
+      if (document.hidden) {
+        stop();
+      } else {
+        tick();
+        start();
+      }
+    };
+
+    if (typeof document === 'undefined' || !document.hidden) start();
+    try {
+      if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', onVisibilityChange);
+      }
+    } catch { /* SSR guard */ }
+
+    return () => {
+      stop();
+      try {
+        if (typeof document !== 'undefined') {
+          document.removeEventListener('visibilitychange', onVisibilityChange);
+        }
+      } catch { /* SSR guard */ }
+    };
+  // flushRef é stable ref atualizada a cada render (linha 91), garantindo que o tick
+  // sempre chame a versão mais recente de runFlushQueue sem causar reset do interval.
+  }, [syncState?.pending, userId]);
 
   return { syncState, setSyncState, refreshSyncState, runFlushQueue };
 }

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { isNativePlatform } from '@/utils/platform'
 import { logWarn } from '@/lib/logger'
 
@@ -9,7 +9,16 @@ type PushPermission = { receive: string }
 type PushToken = { value: string }
 type DeviceId = { identifier: string }
 
+// TTL para dedupe do mesmo action ID (ms). Em iOS, WKWebView pode re-entregar
+// o mesmo `pushNotificationActionPerformed` durante cold-launch + warm-launch.
+const ACTION_DEDUPE_TTL_MS = 5000
+
 export function usePushNotifications(userId?: string | null) {
+  // Persiste entre re-mounts (hot reload em dev / re-execução do effect): se
+  // o último action ID for igual ao recebido dentro do TTL, ignorar o dispatch
+  // pra evitar navegação duplicada.
+  const lastActionRef = useRef<{ id: string; at: number } | null>(null)
+
   useEffect(() => {
     if (!isNativePlatform()) return
     if (!userId) return
@@ -111,7 +120,25 @@ export function usePushNotifications(userId?: string | null) {
               const link = data ? String(data.link || '').trim() : ''
               const type = data ? String(data.type || '').trim() : ''
               if (link || type) {
+                // Dedupe: iOS WKWebView pode re-entregar o mesmo action durante
+                // cold-launch + warm-launch. Se o mesmo action ID chegou nos
+                // últimos 5s, skip o dispatch pra evitar navegação duplicada.
+                // Se ID for falsy (raro), pular dedupe e dispatchar sempre.
+                const actionId = notification ? String(notification.id || '').trim() : ''
+                const now = Date.now()
+                const last = lastActionRef.current
+                if (
+                  actionId &&
+                  last &&
+                  last.id === actionId &&
+                  now - last.at < ACTION_DEDUPE_TTL_MS
+                ) {
+                  return
+                }
                 window.dispatchEvent(new CustomEvent('irontracks:push:navigate', { detail: { link, type } }))
+                if (actionId) {
+                  lastActionRef.current = { id: actionId, at: now }
+                }
               }
             } catch (e) {
               logWarn('usePushNotifications', 'pushNotificationActionPerformed error', e)


### PR DESCRIPTION
## Summary

Fecha os 9 findings restantes (5 🟡 médios + 4 🟢 baixos) do `LATENT_BUGS.md` — completando o audit. Junto com PRs #103/#104/#105, agora estão **todos os 16 bugs resolvidos**.

3 commits separados por tema:

### Commit 1 — UX/Persistência (B-006, B-012)
- **B-006** dedupe de push action via `lastActionRef` + TTL 5s — evita navegação duplicada em iOS warm-launch
- **B-012** restore de sessão ativa também em `/dashboard/active` (não só `/dashboard` exato) — Capacitor preservava URL após crash

### Commit 2 — Bateria (B-008, B-009, B-010)
5 setIntervals (15s + 15s + 15s + 20s + 20s) agora pausam em `document.hidden`:
- `useOfflineSync` flush queue
- `useTeamPresence` upsert
- `useTeamBroadcast` poll msgs
- `useTeamInvites` 2 polls (integrei com listener visibility existente sem duplicar)

Frequências preservadas. Tick imediato ao voltar visible pra refresh.

### Commit 3 — Observabilidade (B-013, B-014, B-015, B-016)
- 12 catches silenciados → `logWarn` com contexto específico (Sentry vai capturar)
- `useCheckins` setTimeout(0) anti-pattern → derived state `hasActiveQuery` curto-circuita return do hook

## Stats da sessão completa (PRs #103-106)

| Categoria | Count |
|-----------|-------|
| 🔴 Críticos resolvidos | 7 (avatar #103, sessão #104, B-001..004 + B-007) |
| 🟡 Médios resolvidos | 5 (B-006, B-008, B-009, B-010, B-012) |
| 🟢 Baixos resolvidos | 4 (B-013, B-014, B-015, B-016) |
| **Total bugs** | **16** ✓ |

## Test plan

- [ ] iOS: push notification → reabrir app → não duplica navegação
- [ ] iOS: iniciar treino → crashar em `/dashboard/active/xyz` → reabrir → banner de restore aparece
- [ ] iOS: backgroundar app → verificar uso de bateria em Settings (deve cair)
- [ ] Web: trocar abas → DevTools Network → confirmar que polls Supabase param em hidden
- [ ] Quebrar `NEXT_PUBLIC_SUPABASE_URL` em dev → confirmar `logWarn` aparece no console

🤖 Generated with [Claude Code](https://claude.com/claude-code)