### PR TITLE
feat(workout): tocar na tela verde de descanso dispensa ela (mantém a barra START)

### DIFF
--- a/src/components/workout/RestTimerOverlay.tsx
+++ b/src/components/workout/RestTimerOverlay.tsx
@@ -59,6 +59,16 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
     // Without this, the overlay stays visible for 1-2 frames after tap, during which
     // re-renders can interfere with the button's click handling on iOS WKWebView.
     const [dismissed, setDismissed] = useState(false);
+    // Flash dismiss: tapping the green "BORA!" flash hides ONLY the flash,
+    // keeping the bottom bar (timer + START + AUTO) visible. Lets the user
+    // peek at the upcoming sets in the workout list below WITHOUT pressing
+    // START — START would begin the exercise execution timer.
+    //
+    // Tracked as "which targetTime was the flash dismissed for" instead of a
+    // plain boolean: when the next rest starts, targetTime changes and the
+    // flash automatically shows again — no setState-in-effect needed.
+    const [flashDismissedForTarget, setFlashDismissedForTarget] = useState<number | null>(null);
+    const flashDismissed = targetTime != null && flashDismissedForTarget === targetTime;
     // AUTO: persisted in localStorage so the user's preference survives across
     // sets, sessions and app restarts. When ON, the overlay auto-advances 500 ms
     // after the countdown reaches zero.
@@ -518,12 +528,15 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
 
     return (
         <>
-            {/* Finished flash — pointer capture prevents accidental taps on workout modal below */}
-            {isFinished && !isTransition && (
+            {/* Finished flash — tap anywhere to hide it (keeps the bottom bar
+                so the user can scan the upcoming sets before pressing START).
+                stopPropagation still guards against the tap leaking to the
+                workout modal below. */}
+            {isFinished && !isTransition && !flashDismissed && (
                 <div
                     role="presentation"
-                    className={`fixed inset-0 z-[2000] backdrop-blur-sm flex flex-col items-center justify-center px-6 overflow-x-hidden ${isSideRest ? 'bg-blue-600/90' : 'bg-green-600/90'}`}
-                    onClick={(e) => e.stopPropagation()}
+                    className={`fixed inset-0 z-[2000] backdrop-blur-sm flex flex-col items-center justify-center px-6 overflow-x-hidden cursor-pointer ${isSideRest ? 'bg-blue-600/90' : 'bg-green-600/90'}`}
+                    onClick={(e) => { e.stopPropagation(); setFlashDismissedForTarget(targetTime ?? null); }}
                     onPointerDown={(e) => e.stopPropagation()}
                     onTouchStart={(e) => e.stopPropagation()}
                 >
@@ -539,6 +552,10 @@ const RestTimerOverlay: React.FC<RestTimerOverlayProps> = ({ targetTime, context
                     ) : (
                         <p className="text-white/80 font-bold mt-2 text-lg">{finishedLabel}</p>
                     )}
+                    {/* Tap hint — sits near the bottom, above the fixed bar */}
+                    <p className="absolute bottom-28 left-0 right-0 text-center text-white/55 font-bold text-xs uppercase tracking-widest">
+                        Toque para ver o treino
+                    </p>
                 </div>
             )}
 


### PR DESCRIPTION
## O que muda

Quando a tela verde "BORA!" (rest finalizado) está aberta, tocar nela agora **dispensa só a tela verde** — a barra de baixo (cronômetro + START + AUTO) continua. Assim o usuário consegue scrollar a lista do treino e ver as próximas séries **sem apertar START**.

## Por quê

Apertar START inicia o cronômetro de execução do exercício. O usuário queria poder "espiar o que vem" sem ser forçado a começar a contar o tempo.

## Detalhe técnico

- A barra de baixo já renderiza sempre (`z-[2100]`, acima da tela verde) — nada mudou nela.
- Novo state rastreia **qual `targetTime`** a tela verde foi dispensada, não um booleano simples. Quando o próximo descanso começa, `targetTime` muda e a tela verde reaparece sozinha — sem `setState` em effect.
- `stopPropagation` mantido no tap pra não vazar pro modal de treino embaixo.
- Adicionada dica "Toque para ver o treino" pra descoberta do gesto.

## Test plan

- [ ] Descanso termina → tela verde "BORA!" aparece com a dica
- [ ] Toca na tela verde → ela some, barra de baixo + lista do treino visíveis
- [ ] Scrolla e vê próximas séries sem o cronômetro de execução rodar
- [ ] Clica START → começa a série normalmente
- [ ] Próximo descanso → tela verde reaparece (não fica permanentemente dispensada)
- [ ] Modo TROCA (unilateral) também dispensa no toque

https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBShHQVaf4EAkBcr8Zj14b)_