### PR TITLE
feat: Avaliação Física por Foto com laudo IA (Gemini Vision)

### DIFF
--- a/src/actions/bodyPhotoAssessment-actions.ts
+++ b/src/actions/bodyPhotoAssessment-actions.ts
@@ -1,0 +1,105 @@
+import { createClient } from '@/utils/supabase/client'
+import { trackUserEvent } from '@/lib/telemetry/userActivity'
+import { logError } from '@/lib/logger'
+import type { ActionResult } from '@/types/actions'
+import type { BodyPhotoAssessment } from '@/types/bodyPhotoAssessment'
+
+/**
+ * Server-side data functions (browser client, RLS-enforced) para a Avaliação
+ * Física por Foto. Apenas ESCRITAS simples ficam aqui — leituras com fotos,
+ * upload e análise IA exigem service role e ficam em API routes
+ * (/api/body-photo/* e /api/ai/body-composition-photo).
+ *
+ * RLS (tabela body_photo_assessments):
+ *   - dono:    auth.uid() = user_id   (autoavaliação)
+ *   - personal: auth.uid() = trainer_id (avalia aluno)
+ */
+
+interface CreateOptions {
+    /** user_id do aluno avaliado (fluxo personal). Omitido = autoavaliação. */
+    studentUserId?: string | null
+    /** Data da avaliação (YYYY-MM-DD). Default = hoje. */
+    assessmentDate?: string | null
+}
+
+export async function createBodyPhotoAssessment(
+    opts: CreateOptions = {},
+): Promise<ActionResult<{ id: string }>> {
+    try {
+        const supabase = createClient()
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user?.id) return { ok: false, error: 'unauthorized' }
+
+        const isTrainerFlow = !!opts.studentUserId && opts.studentUserId !== user.id
+        const targetUserId = isTrainerFlow ? String(opts.studentUserId) : user.id
+
+        const row = {
+            user_id: targetUserId,
+            trainer_id: isTrainerFlow ? user.id : null,
+            created_by: user.id,
+            assessment_date: opts.assessmentDate || new Date().toISOString().slice(0, 10),
+            status: 'pending' as const,
+        }
+
+        const { data, error } = await supabase
+            .from('body_photo_assessments')
+            .insert(row)
+            .select('id')
+            .single()
+
+        if (error) return { ok: false, error: error.message }
+        const id = String((data as { id?: string } | null)?.id || '')
+        if (!id) return { ok: false, error: 'create_failed' }
+
+        try { trackUserEvent('body_photo_assessment_create', { type: 'assessment', metadata: { id, trainer: isTrainerFlow } }) } catch (e) { logError('createBodyPhotoAssessment.track', e) }
+        return { ok: true, data: { id } }
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        return { ok: false, error: message }
+    }
+}
+
+export async function listBodyPhotoAssessmentsMeta(): Promise<ActionResult<BodyPhotoAssessment[]>> {
+    try {
+        const supabase = createClient()
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user?.id) return { ok: false, error: 'unauthorized' }
+
+        const { data, error } = await supabase
+            .from('body_photo_assessments')
+            .select('*')
+            .order('assessment_date', { ascending: false })
+            .order('created_at', { ascending: false })
+            .limit(100)
+
+        if (error) return { ok: false, error: error.message }
+        return { ok: true, data: (data || []) as unknown as BodyPhotoAssessment[] }
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        return { ok: false, error: message }
+    }
+}
+
+export async function deleteBodyPhotoAssessment(id: string): Promise<ActionResult> {
+    try {
+        const assessmentId = String(id || '').trim()
+        if (!assessmentId) return { ok: false, error: 'missing id' }
+        const supabase = createClient()
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user?.id) return { ok: false, error: 'unauthorized' }
+
+        // Fotos somem por ON DELETE CASCADE; objetos do storage são limpos
+        // pelo cron de órfãos (mesma estratégia dos outros buckets privados).
+        const { error } = await supabase
+            .from('body_photo_assessments')
+            .delete()
+            .eq('id', assessmentId)
+
+        if (error) return { ok: false, error: error.message }
+        try { trackUserEvent('body_photo_assessment_delete', { type: 'assessment', metadata: { id: assessmentId } }) } catch (e) { logError('deleteBodyPhotoAssessment.track', e) }
+        return { ok: true, data: undefined }
+    } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        return { ok: false, error: message }
+    }
+}

--- a/src/app/api/ai/body-composition-correlation/route.ts
+++ b/src/app/api/ai/body-composition-correlation/route.ts
@@ -1,0 +1,202 @@
+/**
+ * API: POST /api/ai/body-composition-correlation
+ *
+ * O DIFERENCIAL da avaliação por foto: cruza o laudo da foto com o volume
+ * REAL treinado na janela entre a avaliação anterior e a atual (ou 90 dias).
+ * Como body_photo_assessments.user_id == workouts.user_id, dá pra explicar a
+ * evolução do físico com base no que a pessoa de fato treinou.
+ *
+ * On-demand (sem persistência): cada chamada recomputa com os dados mais
+ * recentes de treino. Acesso: dono (user_id) ou personal (trainer_id).
+ * Rate limit: 5 req/min.
+ */
+import { NextResponse } from 'next/server'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { z } from 'zod'
+import { requireUser } from '@/utils/auth/route'
+import { createAdminClient } from '@/utils/supabase/admin'
+import { checkRateLimitAsync, getRequestIp } from '@/utils/rateLimit'
+import { parseJsonBody, parseJsonWithSchema } from '@/utils/zod'
+import { env } from '@/utils/env'
+import { safeGemini } from '@/utils/ai/handleGeminiError'
+import { logError } from '@/lib/logger'
+import { aggregateTrainingWindow } from '@/utils/bodyPhoto/trainingWindow'
+import { BodyPhotoCorrelationSchema, type TrainingWindowSummary } from '@/types/bodyPhotoAssessment'
+
+export const dynamic = 'force-dynamic'
+
+const DEFAULT_LOOKBACK_DAYS = 90
+const BodySchema = z.object({ assessmentId: z.string().uuid() }).strip()
+
+const safeJsonParse = (raw: unknown) => parseJsonWithSchema(raw, z.unknown())
+function extractJson(text: string): unknown {
+    let cleaned = String(text || '').trim()
+    if (!cleaned) return null
+    const fence = cleaned.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/m)
+    if (fence?.[1]) cleaned = fence[1].trim()
+    const direct = safeJsonParse(cleaned)
+    if (direct) return direct
+    const s = cleaned.indexOf('{')
+    const e = cleaned.lastIndexOf('}')
+    if (s === -1 || e <= s) return null
+    return safeJsonParse(cleaned.slice(s, e + 1))
+}
+
+const dayStr = (d: Date) => d.toISOString().slice(0, 10)
+
+export async function POST(req: Request) {
+    try {
+        const auth = await requireUser()
+        if (!auth.ok) return auth.response
+        const userId = String(auth.user.id || '').trim()
+
+        const ip = getRequestIp(req)
+        const rl = await checkRateLimitAsync(`ai:body-correlation:${userId}:${ip}`, 5, 60_000)
+        if (!rl.allowed) return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 })
+
+        const apiKey = env.gemini.apiKey
+        if (!apiKey) return NextResponse.json({ ok: false, error: 'ai_not_configured' }, { status: 500 })
+
+        const parsed = await parseJsonBody(req, BodySchema)
+        if (parsed.response) return parsed.response
+        const { assessmentId } = parsed.data!
+
+        const admin = createAdminClient()
+
+        // Avaliação atual + access check
+        const { data: current, error: cErr } = await admin
+            .from('body_photo_assessments')
+            .select('id, user_id, trainer_id, assessment_date, analysis, composition_score, symmetry_score, posture_score, proportion_score, body_fat_estimate_low, body_fat_estimate_high')
+            .eq('id', assessmentId)
+            .maybeSingle()
+        if (cErr) return NextResponse.json({ ok: false, error: cErr.message }, { status: 400 })
+        if (!current) return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+        const cur = current as Record<string, unknown>
+        const assessedUserId = String(cur.user_id || '')
+        if (userId !== assessedUserId && userId !== (cur.trainer_id || null)) {
+            return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 })
+        }
+        if (!cur.analysis) {
+            return NextResponse.json({ ok: false, error: 'no_analysis', message: 'Gere o laudo da foto antes de correlacionar com o treino.' }, { status: 400 })
+        }
+
+        const thisDate = new Date(`${String(cur.assessment_date)}T00:00:00Z`)
+
+        // Avaliação anterior (mesma pessoa) → define início da janela + delta
+        const { data: prevRows } = await admin
+            .from('body_photo_assessments')
+            .select('id, assessment_date, composition_score, symmetry_score, posture_score, proportion_score, body_fat_estimate_low, body_fat_estimate_high')
+            .eq('user_id', assessedUserId)
+            .lt('assessment_date', String(cur.assessment_date))
+            .order('assessment_date', { ascending: false })
+            .limit(1)
+        const previous = (prevRows && prevRows[0]) ? (prevRows[0] as Record<string, unknown>) : null
+
+        const fromDate = previous
+            ? new Date(`${String(previous.assessment_date)}T00:00:00Z`)
+            : new Date(thisDate.getTime() - DEFAULT_LOOKBACK_DAYS * 86400_000)
+        const toEnd = new Date(thisDate.getTime() + 86400_000 - 1)
+        const fromIso = fromDate.toISOString()
+        const toIso = toEnd.toISOString()
+
+        // Sessões concluídas na janela (completed_at e fallback por date)
+        const merged = new Map<string, { notes?: unknown }>()
+        const collect = (rows: unknown) => {
+            if (!Array.isArray(rows)) return
+            for (const r of rows) {
+                const row = r as { id?: string; notes?: unknown }
+                if (row?.id) merged.set(String(row.id), { notes: row.notes })
+            }
+        }
+        const { data: byCompleted } = await admin
+            .from('workouts')
+            .select('id, notes, completed_at')
+            .eq('user_id', assessedUserId)
+            .eq('is_template', false)
+            .gte('completed_at', fromIso)
+            .lte('completed_at', toIso)
+        collect(byCompleted)
+        const { data: byDate } = await admin
+            .from('workouts')
+            .select('id, notes, date')
+            .eq('user_id', assessedUserId)
+            .eq('is_template', false)
+            .gte('date', dayStr(fromDate))
+            .lte('date', dayStr(thisDate))
+        collect(byDate)
+
+        const stats = aggregateTrainingWindow([...merged.values()])
+        const window: TrainingWindowSummary = {
+            fromIso,
+            toIso,
+            hasPreviousAssessment: !!previous,
+            sessions: stats.sessions,
+            totalVolumeKg: stats.totalVolumeKg,
+            totalSets: stats.totalSets,
+            topExercises: stats.topExercises,
+        }
+
+        const promptData = {
+            laudoAtual: cur.analysis,
+            scoresAtuais: {
+                composition: cur.composition_score, symmetry: cur.symmetry_score,
+                posture: cur.posture_score, proportion: cur.proportion_score,
+                bodyFat: [cur.body_fat_estimate_low, cur.body_fat_estimate_high],
+            },
+            avaliacaoAnterior: previous
+                ? {
+                    scores: {
+                        composition: previous.composition_score, symmetry: previous.symmetry_score,
+                        posture: previous.posture_score, proportion: previous.proportion_score,
+                        bodyFat: [previous.body_fat_estimate_low, previous.body_fat_estimate_high],
+                    },
+                }
+                : null,
+            treinoNaJanela: {
+                dias: Math.round((toEnd.getTime() - fromDate.getTime()) / 86400_000),
+                sessoes: stats.sessions,
+                volumeTotalKg: stats.totalVolumeKg,
+                seriesTotais: stats.totalSets,
+                topExercicios: stats.topExercises,
+            },
+        }
+
+        const prompt = [
+            'Você é um educador físico. Correlacione o LAUDO da avaliação por foto com o TREINO REAL executado na janela.',
+            'Use seu conhecimento de quais músculos cada exercício trabalha (pelos nomes em topExercicios).',
+            'Seja concreto e cite números do treino (volume, séries, sessões). Se houver avaliação anterior, comente a evolução dos scores.',
+            'Se não houver treino registrado na janela, diga isso com clareza e baixe a confiança.',
+            '',
+            'Retorne APENAS JSON puro:',
+            '{',
+            '  "headline": "frase de impacto citando treino e físico",',
+            '  "narrative": "explicação correlacionando treino executado e físico observado",',
+            '  "whatIsWorking": ["o que o treino está sustentando no físico"],',
+            '  "whatIsMissing": ["lacunas: grupos pouco treinados vs. pontos fracos do laudo"],',
+            '  "links": [{ "muscleGroup": "Peitoral", "observation": "texto citando volume", "trend": "supported|undertrained|overtrained|neutral" }],',
+            '  "nextFocus": [{ "focus": "grupo/área", "action": "ajuste concreto de treino" }],',
+            '  "confidence": "high|medium|low"',
+            '}',
+            '',
+            'DADOS:',
+            JSON.stringify(promptData),
+        ].join('\n')
+
+        const genAI = new GoogleGenerativeAI(apiKey)
+        const model = genAI.getGenerativeModel({ model: env.gemini.modelId })
+        const geminiResult = await safeGemini('body-composition-correlation', () => model.generateContent(prompt))
+        if ('errorResponse' in geminiResult) return geminiResult.errorResponse
+
+        const rawText = geminiResult.value?.response?.text?.() || ''
+        const validated = BodyPhotoCorrelationSchema.safeParse(extractJson(rawText))
+        if (!validated.success) {
+            logError('ai:body-composition-correlation:invalid', new Error('schema mismatch'), { rawPreview: String(rawText).slice(0, 200) })
+            return NextResponse.json({ ok: false, error: 'correlation_failed', message: 'Não consegui gerar a correlação. Tente novamente.' }, { status: 422 })
+        }
+
+        return NextResponse.json({ ok: true, correlation: validated.data, window })
+    } catch (e) {
+        logError('ai:body-composition-correlation', e)
+        return NextResponse.json({ ok: false, error: 'internal' }, { status: 500 })
+    }
+}

--- a/src/app/api/ai/body-composition-photo/route.ts
+++ b/src/app/api/ai/body-composition-photo/route.ts
@@ -1,0 +1,195 @@
+/**
+ * API: POST /api/ai/body-composition-photo
+ *
+ * O coração da Avaliação Física por Foto. Recebe assessmentId, baixa as fotos
+ * (frente/perfil/costas) do bucket PRIVADO body-photos e gera um laudo
+ * estruturado de composição corporal via Gemini Vision: faixa de % gordura,
+ * scores 0–100 (composição/simetria/postura/proporção), avaliação por grupo
+ * muscular, postura, simetria L/R, proporções e recomendações priorizadas.
+ *
+ * Acesso: dono (user_id) OU personal (trainer_id). Admin client + checagem.
+ * Modelo: Pro (qualidade do laudo importa; não é OCR simples).
+ * Rate limit: 5 req/min (chamada de IA cara).
+ */
+import { NextResponse } from 'next/server'
+import { GoogleGenerativeAI, type Part } from '@google/generative-ai'
+import { z } from 'zod'
+import { requireUser } from '@/utils/auth/route'
+import { createAdminClient } from '@/utils/supabase/admin'
+import { checkRateLimitAsync, getRequestIp } from '@/utils/rateLimit'
+import { parseJsonBody, parseJsonWithSchema } from '@/utils/zod'
+import { env } from '@/utils/env'
+import { safeGemini } from '@/utils/ai/handleGeminiError'
+import { logError } from '@/lib/logger'
+import { BodyPhotoLaudoSchema, POSE_LABELS_PT, type BodyPhotoPose } from '@/types/bodyPhotoAssessment'
+
+export const dynamic = 'force-dynamic'
+
+const BUCKET = 'body-photos'
+const POSE_ORDER: BodyPhotoPose[] = ['front', 'side', 'back']
+
+const BodySchema = z.object({ assessmentId: z.string().uuid() }).strip()
+
+const safeJsonParse = (raw: unknown) => parseJsonWithSchema(raw, z.unknown())
+
+function extractJson(text: string): unknown {
+    let cleaned = String(text || '').trim()
+    if (!cleaned) return null
+    const fence = cleaned.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/m)
+    if (fence?.[1]) cleaned = fence[1].trim()
+    const direct = safeJsonParse(cleaned)
+    if (direct) return direct
+    const start = cleaned.indexOf('{')
+    const end = cleaned.lastIndexOf('}')
+    if (start === -1 || end <= start) return null
+    return safeJsonParse(cleaned.slice(start, end + 1))
+}
+
+const PROMPT = [
+    'Você é um educador físico especialista em avaliação física e biomecânica.',
+    'Recebe de 1 a 3 fotos padronizadas do MESMO indivíduo (frente, perfil, costas).',
+    'Produza uma análise visual profissional de composição corporal e estrutura.',
+    '',
+    'IMPORTANTE — limites e ética:',
+    '- É uma ESTIMATIVA visual, não diagnóstico médico nem laboratorial.',
+    '- % de gordura SEMPRE como FAIXA (ex.: 14–17%), nunca número exato falso.',
+    '- Se a foto não permitir avaliar algo, seja conservador e baixe a confiança.',
+    '- Linguagem técnica mas acessível, em português-BR, tom de personal trainer.',
+    '',
+    'AVALIE:',
+    '- bodyFatRange: faixa de % de gordura (low/high).',
+    '- somatotype: somatotipo aparente (ectomorfo/mesomorfo/endomorfo ou misto) ou null.',
+    '- apparentPhase: bulking | cutting | recomp | maintenance | unknown.',
+    '- scores (0–100): composition (composição), symmetry (simetria L/R),',
+    '  posture (postura), proportion (proporções/V-taper).',
+    '- muscleGroups: lista por grupo (Peitoral, Ombros, Costas, Bíceps, Tríceps,',
+    '  Abdômen, Quadríceps, Posterior, Glúteos, Panturrilhas) com development',
+    '  (weak|moderate|good|excellent) e note curta.',
+    '- posture: summary + findings (ex.: "leve anteriorização de ombros").',
+    '- symmetry: summary + imbalances (assimetrias L vs R observáveis).',
+    '- proportions: summary + shoulderToWaist (descritivo) ou null.',
+    '- strengths, improvements: listas curtas.',
+    '- recommendations: foco + ação concreta + priority (high|medium|low).',
+    '- summary: resumo executivo 2–4 frases.',
+    '- confidence: high|medium|low conforme a qualidade/ângulo das fotos.',
+    '',
+    'RESPONDA APENAS JSON PURO (sem markdown, sem texto fora do JSON):',
+    '{',
+    '  "bodyFatRange": { "low": número, "high": número },',
+    '  "somatotype": texto|null,',
+    '  "apparentPhase": "bulking"|"cutting"|"recomp"|"maintenance"|"unknown",',
+    '  "scores": { "composition": número, "symmetry": número, "posture": número, "proportion": número },',
+    '  "muscleGroups": [{ "group": texto, "development": "weak"|"moderate"|"good"|"excellent", "note": texto }],',
+    '  "posture": { "summary": texto, "findings": [texto] },',
+    '  "symmetry": { "summary": texto, "imbalances": [texto] },',
+    '  "proportions": { "summary": texto, "shoulderToWaist": texto|null },',
+    '  "strengths": [texto], "improvements": [texto],',
+    '  "recommendations": [{ "focus": texto, "action": texto, "priority": "high"|"medium"|"low" }],',
+    '  "summary": texto, "confidence": "high"|"medium"|"low"',
+    '}',
+].join('\n')
+
+export async function POST(req: Request) {
+    try {
+        const auth = await requireUser()
+        if (!auth.ok) return auth.response
+        const userId = String(auth.user.id || '').trim()
+
+        const ip = getRequestIp(req)
+        const rl = await checkRateLimitAsync(`ai:body-photo:${userId}:${ip}`, 5, 60_000)
+        if (!rl.allowed) return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 })
+
+        const apiKey = env.gemini.apiKey
+        if (!apiKey) return NextResponse.json({ ok: false, error: 'ai_not_configured' }, { status: 500 })
+
+        const parsed = await parseJsonBody(req, BodySchema)
+        if (parsed.response) return parsed.response
+        const { assessmentId } = parsed.data!
+
+        const admin = createAdminClient()
+
+        // Access check
+        const { data: assessment, error: aErr } = await admin
+            .from('body_photo_assessments')
+            .select('id, user_id, trainer_id')
+            .eq('id', assessmentId)
+            .maybeSingle()
+        if (aErr) return NextResponse.json({ ok: false, error: aErr.message }, { status: 400 })
+        if (!assessment) return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+        const a = assessment as { user_id: string; trainer_id: string | null }
+        if (userId !== a.user_id && userId !== a.trainer_id) {
+            return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 })
+        }
+
+        // Carrega fotos
+        const { data: photosRaw } = await admin
+            .from('body_photo_assessment_photos')
+            .select('pose, storage_path')
+            .eq('assessment_id', assessmentId)
+        const photos = (photosRaw || []) as Array<{ pose: BodyPhotoPose; storage_path: string }>
+        if (photos.length === 0) {
+            return NextResponse.json({ ok: false, error: 'no_photos' }, { status: 400 })
+        }
+
+        // marca analisando
+        await admin.from('body_photo_assessments').update({ status: 'analyzing' }).eq('id', assessmentId)
+
+        // Baixa cada foto do bucket privado e monta partes multimodais (ordenadas)
+        const ordered = [...photos].sort((x, y) => POSE_ORDER.indexOf(x.pose) - POSE_ORDER.indexOf(y.pose))
+        const parts: Part[] = [{ text: PROMPT }]
+        for (const ph of ordered) {
+            const { data: blob, error: dErr } = await admin.storage.from(BUCKET).download(ph.storage_path)
+            if (dErr || !blob) continue
+            const base64 = Buffer.from(await blob.arrayBuffer()).toString('base64')
+            parts.push({ text: `\nFOTO ${POSE_LABELS_PT[ph.pose].toUpperCase()}:` })
+            parts.push({ inlineData: { mimeType: 'image/jpeg', data: base64 } })
+        }
+        if (parts.length <= 1) {
+            await admin.from('body_photo_assessments').update({ status: 'failed' }).eq('id', assessmentId)
+            return NextResponse.json({ ok: false, error: 'photos_unreadable' }, { status: 400 })
+        }
+
+        const genAI = new GoogleGenerativeAI(apiKey)
+        const model = genAI.getGenerativeModel({ model: env.gemini.modelId })
+        const geminiResult = await safeGemini('body-composition-photo', () => model.generateContent(parts))
+        if ('errorResponse' in geminiResult) {
+            await admin.from('body_photo_assessments').update({ status: 'failed' }).eq('id', assessmentId)
+            return geminiResult.errorResponse
+        }
+
+        const rawText = geminiResult.value?.response?.text?.() || ''
+        const extracted = extractJson(rawText)
+        const validated = BodyPhotoLaudoSchema.safeParse(extracted)
+        if (!validated.success) {
+            logError('ai:body-composition-photo:invalid', new Error('schema mismatch'), { rawPreview: String(rawText).slice(0, 200) })
+            await admin.from('body_photo_assessments').update({ status: 'failed' }).eq('id', assessmentId)
+            return NextResponse.json(
+                { ok: false, error: 'analysis_failed', message: 'Não consegui analisar as fotos. Confira se aparecem o corpo inteiro com boa luz e tente de novo.' },
+                { status: 422 },
+            )
+        }
+
+        const laudo = validated.data
+        const { error: saveErr } = await admin
+            .from('body_photo_assessments')
+            .update({
+                analysis: laudo,
+                composition_score: laudo.scores.composition,
+                symmetry_score: laudo.scores.symmetry,
+                posture_score: laudo.scores.posture,
+                proportion_score: laudo.scores.proportion,
+                body_fat_estimate_low: laudo.bodyFatRange.low,
+                body_fat_estimate_high: laudo.bodyFatRange.high,
+                ai_model: env.gemini.modelId,
+                ai_analyzed_at: new Date().toISOString(),
+                status: 'done',
+            })
+            .eq('id', assessmentId)
+        if (saveErr) return NextResponse.json({ ok: false, error: saveErr.message }, { status: 400 })
+
+        return NextResponse.json({ ok: true, analysis: laudo })
+    } catch (e) {
+        logError('ai:body-composition-photo', e)
+        return NextResponse.json({ ok: false, error: 'internal' }, { status: 500 })
+    }
+}

--- a/src/app/api/body-photo/assessments/route.ts
+++ b/src/app/api/body-photo/assessments/route.ts
@@ -1,0 +1,97 @@
+/**
+ * API: GET /api/body-photo/assessments
+ *   - sem ?id      → lista as avaliações acessíveis (dono OU personal),
+ *                    com signed URL da foto de frente como thumbnail.
+ *   - com ?id=UUID → detalhe de uma avaliação + todas as fotos com signed URLs.
+ *
+ * Bucket body-photos é PRIVADO: toda leitura de imagem passa por signed URL
+ * mintada aqui (admin) após checagem de acesso. Foto de corpo nunca é pública.
+ */
+import { NextResponse } from 'next/server'
+import { requireUser } from '@/utils/auth/route'
+import { createAdminClient } from '@/utils/supabase/admin'
+import { getErrorMessage } from '@/utils/errorMessage'
+import type { BodyPhotoAssessment, BodyPhotoAssessmentPhoto } from '@/types/bodyPhotoAssessment'
+
+export const dynamic = 'force-dynamic'
+
+const BUCKET = 'body-photos'
+const SIGNED_TTL = 60 * 60 // 1h
+
+export async function GET(request: Request) {
+    try {
+        const auth = await requireUser()
+        if (!auth.ok) return auth.response
+        const userId = String(auth.user.id || '').trim()
+
+        const url = new URL(request.url)
+        const id = (url.searchParams.get('id') || '').trim()
+        const admin = createAdminClient()
+
+        // ── Detalhe ──────────────────────────────────────────────────────────
+        if (id) {
+            const { data: assessment, error } = await admin
+                .from('body_photo_assessments')
+                .select('*')
+                .eq('id', id)
+                .maybeSingle()
+            if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+            if (!assessment) return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+
+            const a = assessment as unknown as BodyPhotoAssessment
+            if (userId !== a.user_id && userId !== a.trainer_id) {
+                return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 })
+            }
+
+            const { data: photos } = await admin
+                .from('body_photo_assessment_photos')
+                .select('*')
+                .eq('assessment_id', id)
+
+            const photoRows = (photos || []) as unknown as BodyPhotoAssessmentPhoto[]
+            const withUrls = await Promise.all(
+                photoRows.map(async (p) => {
+                    const { data: s } = await admin.storage.from(BUCKET).createSignedUrl(p.storage_path, SIGNED_TTL)
+                    return { ...p, signedUrl: s?.signedUrl ?? null }
+                }),
+            )
+
+            return NextResponse.json({ ok: true, assessment: a, photos: withUrls })
+        }
+
+        // ── Lista ────────────────────────────────────────────────────────────
+        const { data: rows, error } = await admin
+            .from('body_photo_assessments')
+            .select('*')
+            .or(`user_id.eq.${userId},trainer_id.eq.${userId}`)
+            .order('assessment_date', { ascending: false })
+            .order('created_at', { ascending: false })
+            .limit(100)
+        if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+        const list = (rows || []) as unknown as BodyPhotoAssessment[]
+        if (list.length === 0) return NextResponse.json({ ok: true, assessments: [] })
+
+        // Thumbnail = foto de frente de cada avaliação
+        const ids = list.map((a) => a.id)
+        const { data: fronts } = await admin
+            .from('body_photo_assessment_photos')
+            .select('assessment_id, storage_path')
+            .in('assessment_id', ids)
+            .eq('pose', 'front')
+
+        const thumbByAssessment = new Map<string, string>()
+        const frontRows = (fronts || []) as Array<{ assessment_id: string; storage_path: string }>
+        await Promise.all(
+            frontRows.map(async (f) => {
+                const { data: s } = await admin.storage.from(BUCKET).createSignedUrl(f.storage_path, SIGNED_TTL)
+                if (s?.signedUrl) thumbByAssessment.set(f.assessment_id, s.signedUrl)
+            }),
+        )
+
+        const withThumbs = list.map((a) => ({ ...a, thumbnailUrl: thumbByAssessment.get(a.id) ?? null }))
+        return NextResponse.json({ ok: true, assessments: withThumbs })
+    } catch (e: unknown) {
+        return NextResponse.json({ ok: false, error: getErrorMessage(e) }, { status: 500 })
+    }
+}

--- a/src/app/api/body-photo/signed-upload/route.ts
+++ b/src/app/api/body-photo/signed-upload/route.ts
@@ -1,0 +1,103 @@
+/**
+ * API: POST /api/body-photo/signed-upload
+ *
+ * Minta um signed upload URL pro bucket PRIVADO body-photos e registra (upsert)
+ * a linha da foto em body_photo_assessment_photos. O cliente faz o PUT do
+ * arquivo com uploadToSignedUrl(path, token, file).
+ *
+ * Acesso: dono (user_id) OU personal (trainer_id) da avaliação. Checagem
+ * explícita porque usamos admin client (service role bypassa RLS).
+ *
+ * Path: {assessed_user_id}/{assessmentId}/{pose}.jpg — sempre sob o prefixo do
+ * AVALIADO (não de quem sobe), pra casar com o RLS de prefixo do storage e com
+ * o signing de leitura.
+ *
+ * Rate limit: 30 req/min por usuário (3 fotos × algumas tentativas).
+ */
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireUser } from '@/utils/auth/route'
+import { createAdminClient } from '@/utils/supabase/admin'
+import { checkRateLimitAsync, getRequestIp } from '@/utils/rateLimit'
+import { parseJsonBody } from '@/utils/zod'
+import { getErrorMessage } from '@/utils/errorMessage'
+import { BODY_PHOTO_POSES } from '@/types/bodyPhotoAssessment'
+
+export const dynamic = 'force-dynamic'
+
+const BUCKET = 'body-photos'
+
+const BodySchema = z
+    .object({
+        assessmentId: z.string().uuid(),
+        pose: z.enum(BODY_PHOTO_POSES),
+        width: z.number().int().positive().max(20000).nullable().optional(),
+        height: z.number().int().positive().max(20000).nullable().optional(),
+        fileSize: z.number().int().positive().max(25 * 1024 * 1024).nullable().optional(),
+        mimeType: z.string().max(80).nullable().optional(),
+    })
+    .strip()
+
+export async function POST(request: Request) {
+    try {
+        const auth = await requireUser()
+        if (!auth.ok) return auth.response
+        const userId = String(auth.user.id || '').trim()
+
+        const ip = getRequestIp(request)
+        const rl = await checkRateLimitAsync(`body-photo:upload:${userId}:${ip}`, 30, 60_000)
+        if (!rl.allowed) return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 })
+
+        const parsed = await parseJsonBody(request, BodySchema)
+        if (parsed.response) return parsed.response
+        const { assessmentId, pose, width, height, fileSize, mimeType } = parsed.data!
+
+        const admin = createAdminClient()
+
+        // Access check: dono ou personal da avaliação
+        const { data: assessment, error: aErr } = await admin
+            .from('body_photo_assessments')
+            .select('id, user_id, trainer_id')
+            .eq('id', assessmentId)
+            .maybeSingle()
+        if (aErr) return NextResponse.json({ ok: false, error: aErr.message }, { status: 400 })
+        if (!assessment) return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 })
+
+        const assessedUserId = String((assessment as { user_id?: string }).user_id || '')
+        const trainerId = (assessment as { trainer_id?: string | null }).trainer_id || null
+        if (userId !== assessedUserId && userId !== trainerId) {
+            return NextResponse.json({ ok: false, error: 'forbidden' }, { status: 403 })
+        }
+
+        const path = `${assessedUserId}/${assessmentId}/${pose}.jpg`
+
+        const { data: signed, error: signErr } = await admin.storage
+            .from(BUCKET)
+            .createSignedUploadUrl(path, { upsert: true })
+        if (signErr || !signed) {
+            return NextResponse.json({ ok: false, error: signErr?.message || 'failed_to_sign' }, { status: 400 })
+        }
+
+        // Upsert da linha da foto (uma por pose por avaliação — UNIQUE constraint)
+        const { error: upErr } = await admin
+            .from('body_photo_assessment_photos')
+            .upsert(
+                {
+                    assessment_id: assessmentId,
+                    user_id: assessedUserId,
+                    pose,
+                    storage_path: path,
+                    width: width ?? null,
+                    height: height ?? null,
+                    file_size: fileSize ?? null,
+                    mime_type: mimeType ?? null,
+                },
+                { onConflict: 'assessment_id,pose' },
+            )
+        if (upErr) return NextResponse.json({ ok: false, error: upErr.message }, { status: 400 })
+
+        return NextResponse.json({ ok: true, path: signed.path, token: signed.token })
+    } catch (e: unknown) {
+        return NextResponse.json({ ok: false, error: getErrorMessage(e) }, { status: 500 })
+    }
+}

--- a/src/components/assessment/AssessmentHeader.tsx
+++ b/src/components/assessment/AssessmentHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Activity, User, X } from 'lucide-react'
+import { Activity, Camera, User, X } from 'lucide-react'
 
 type AssessmentHeaderProps = {
   onCreate: () => void
@@ -13,6 +13,11 @@ type AssessmentHeaderProps = {
    * só faz sentido a avaliação completa.
    */
   onAddBia?: () => void
+  /**
+   * Quando definido, exibe o botão "Por Foto" que abre a avaliação por
+   * foto com laudo de IA (composição corporal via Gemini Vision).
+   */
+  onPhotoAssessment?: () => void
 }
 
 export const AssessmentHeader = ({
@@ -20,9 +25,11 @@ export const AssessmentHeader = ({
   onShowHistory,
   onClose,
   onAddBia,
+  onPhotoAssessment,
 }: AssessmentHeaderProps) => {
-  // Layout: 3 colunas quando tem o botão BIA, 2 quando não.
-  const cols = onAddBia ? 'sm:grid-cols-3' : 'sm:grid-cols-2'
+  // Layout: nº de colunas = nº de botões (Nova + Histórico são fixos).
+  const count = 2 + (onAddBia ? 1 : 0) + (onPhotoAssessment ? 1 : 0)
+  const cols = count >= 4 ? 'sm:grid-cols-4' : count === 3 ? 'sm:grid-cols-3' : 'sm:grid-cols-2'
   return (
     <div
       className="rounded-2xl border p-6 mb-6 relative overflow-hidden"
@@ -69,6 +76,21 @@ export const AssessmentHeader = ({
               >
                 <Activity className="w-4 h-4" />
                 Bioimpedância
+              </button>
+            ) : null}
+            {onPhotoAssessment ? (
+              <button
+                onClick={onPhotoAssessment}
+                className="w-full min-h-[44px] px-4 py-2 rounded-xl border font-bold transition-all duration-300 active:scale-95 inline-flex items-center justify-center gap-2"
+                style={{
+                  background: 'rgba(168,85,247,0.08)',
+                  borderColor: 'rgba(168,85,247,0.30)',
+                  color: '#d8b4fe',
+                }}
+                title="Avaliação por foto com laudo de IA (composição corporal)"
+              >
+                <Camera className="w-4 h-4" />
+                Por Foto
               </button>
             ) : null}
             <button

--- a/src/components/assessment/AssessmentHistory.tsx
+++ b/src/components/assessment/AssessmentHistory.tsx
@@ -24,6 +24,7 @@ import { AssessmentSummaryCards } from '@/components/assessment/AssessmentSummar
 import { AssessmentListItem, measurementFields, skinfoldFields } from '@/components/assessment/AssessmentListItem';
 import { AssessmentPlanModal } from '@/components/assessment/AssessmentPlanModal';
 import { AssessmentHistoryModal } from './AssessmentHistoryModal';
+import { BodyPhotoCaptureModal } from '@/components/body-photo/BodyPhotoCaptureModal';
 import { useAssessmentHistoryData } from '@/hooks/useAssessmentHistoryData';
 import { ArrowLeft } from 'lucide-react';
 
@@ -62,6 +63,7 @@ export default function AssessmentHistory({ studentId: propStudentId, onClose }:
   const studentId = propStudentId;
   const router = useRouter();
   const [quickBiaOpen, setQuickBiaOpen] = React.useState(false);
+  const [photoModalOpen, setPhotoModalOpen] = React.useState(false);
 
   const {
     // Core data
@@ -139,6 +141,7 @@ export default function AssessmentHistory({ studentId: propStudentId, onClose }:
           onShowHistory={() => {}}
           onClose={undefined}
           onAddBia={studentId ? () => setQuickBiaOpen(true) : undefined}
+          onPhotoAssessment={() => setPhotoModalOpen(true)}
         />
 
         <div
@@ -154,6 +157,11 @@ export default function AssessmentHistory({ studentId: propStudentId, onClose }:
           <h2 className="text-xl font-black text-white mb-2">Nenhuma avaliação encontrada</h2>
           <p className="text-neutral-500 text-sm">Este aluno ainda não possui avaliações físicas registradas.</p>
         </div>
+        <BodyPhotoCaptureModal
+          open={photoModalOpen}
+          onClose={() => setPhotoModalOpen(false)}
+          studentUserId={studentId ?? null}
+        />
       </div>
     );
   }
@@ -167,6 +175,7 @@ export default function AssessmentHistory({ studentId: propStudentId, onClose }:
           onShowHistory={() => setShowHistory(true)}
           onClose={onClose}
           onAddBia={studentId ? () => setQuickBiaOpen(true) : undefined}
+          onPhotoAssessment={() => setPhotoModalOpen(true)}
         />
         {latestAssessment && previousAssessment && (
           <AssessmentSummaryCards
@@ -419,6 +428,13 @@ export default function AssessmentHistory({ studentId: propStudentId, onClose }:
             onSaved={() => { if (typeof window !== 'undefined') location.reload(); }}
           />
         )}
+        {/* Avaliação por foto (laudo IA). studentUserId define self vs personal:
+            o action compara com o usuário logado pra decidir trainer_id. */}
+        <BodyPhotoCaptureModal
+          open={photoModalOpen}
+          onClose={() => setPhotoModalOpen(false)}
+          studentUserId={studentId ?? null}
+        />
       </div>
     </DialogProvider>
   );

--- a/src/components/body-photo/BodyPhotoCaptureModal.tsx
+++ b/src/components/body-photo/BodyPhotoCaptureModal.tsx
@@ -2,12 +2,13 @@
 
 import React, { useCallback, useRef, useState } from 'react'
 import NextImage from 'next/image'
-import { Camera, X, Check, Loader2, Sparkles, RotateCcw } from 'lucide-react'
+import { Camera, X, Check, Loader2, Sparkles, RotateCcw, Dumbbell } from 'lucide-react'
 import { createBodyPhotoAssessment } from '@/actions/bodyPhotoAssessment-actions'
-import { analyzeBodyPhoto } from '@/lib/api/bodyPhoto'
+import { analyzeBodyPhoto, fetchBodyPhotoCorrelation } from '@/lib/api/bodyPhoto'
 import { compressBodyPhoto, uploadBodyPhoto, type CompressedPhoto } from '@/utils/storage/bodyPhotoUpload'
-import { BODY_PHOTO_POSES, POSE_LABELS_PT, type BodyPhotoPose, type BodyPhotoLaudo } from '@/types/bodyPhotoAssessment'
+import { BODY_PHOTO_POSES, POSE_LABELS_PT, type BodyPhotoPose, type BodyPhotoLaudo, type BodyPhotoCorrelation, type TrainingWindowSummary } from '@/types/bodyPhotoAssessment'
 import { BodyPhotoLaudoView } from './BodyPhotoLaudoView'
+import { BodyPhotoCorrelationView } from './BodyPhotoCorrelationView'
 
 type Stage = 'capture' | 'processing' | 'result' | 'error'
 
@@ -47,11 +48,30 @@ export const BodyPhotoCaptureModal: React.FC<Props> = ({ open, onClose, studentU
     const [progress, setProgress] = useState('')
     const [laudo, setLaudo] = useState<BodyPhotoLaudo | null>(null)
     const [errorMsg, setErrorMsg] = useState('')
+    const [assessmentId, setAssessmentId] = useState<string | null>(null)
+    const [correlation, setCorrelation] = useState<{ data: BodyPhotoCorrelation; window: TrainingWindowSummary } | null>(null)
+    const [correlationLoading, setCorrelationLoading] = useState(false)
+    const [correlationError, setCorrelationError] = useState('')
     const inputRefs = useRef<Record<BodyPhotoPose, HTMLInputElement | null>>({ front: null, side: null, back: null })
 
     const reset = useCallback(() => {
         setStage('capture'); setPhotos({}); setProgress(''); setLaudo(null); setErrorMsg(''); setBusyPose(null)
+        setAssessmentId(null); setCorrelation(null); setCorrelationLoading(false); setCorrelationError('')
     }, [])
+
+    const handleCorrelate = useCallback(async () => {
+        if (!assessmentId) return
+        setCorrelationLoading(true); setCorrelationError('')
+        try {
+            const res = await fetchBodyPhotoCorrelation(assessmentId)
+            if (!res.ok || !res.correlation || !res.window) throw new Error(res.message || res.error || 'Falha na correlação.')
+            setCorrelation({ data: res.correlation, window: res.window })
+        } catch (e) {
+            setCorrelationError(e instanceof Error ? e.message : 'Erro inesperado.')
+        } finally {
+            setCorrelationLoading(false)
+        }
+    }, [assessmentId])
 
     const handleClose = useCallback(() => {
         if (stage === 'processing') return // não fecha no meio da análise
@@ -82,6 +102,7 @@ export const BodyPhotoCaptureModal: React.FC<Props> = ({ open, onClose, studentU
             const created = await createBodyPhotoAssessment({ studentUserId: studentUserId ?? null })
             if (!created.ok) throw new Error(created.error || 'Falha ao criar avaliação.')
             const id = created.data.id
+            setAssessmentId(id)
 
             for (const pose of BODY_PHOTO_POSES) {
                 const photo = photos[pose]
@@ -196,7 +217,34 @@ export const BodyPhotoCaptureModal: React.FC<Props> = ({ open, onClose, studentU
                         </div>
                     )}
 
-                    {stage === 'result' && laudo ? <BodyPhotoLaudoView laudo={laudo} /> : null}
+                    {stage === 'result' && laudo ? (
+                        <div className="space-y-5">
+                            <BodyPhotoLaudoView laudo={laudo} />
+
+                            {/* Correlação treino × corpo (on-demand) */}
+                            <div className="pt-2 border-t border-neutral-800">
+                                {correlation ? (
+                                    <BodyPhotoCorrelationView correlation={correlation.data} window={correlation.window} />
+                                ) : (
+                                    <div className="text-center py-2">
+                                        <p className="text-sm text-neutral-400 mb-3">
+                                            Cruze este laudo com o que você de fato treinou no período — só o IronTracks faz isso.
+                                        </p>
+                                        <button
+                                            onClick={handleCorrelate}
+                                            disabled={correlationLoading}
+                                            className="inline-flex items-center justify-center gap-2 min-h-[44px] px-5 rounded-xl border font-bold transition active:scale-95 disabled:opacity-50"
+                                            style={{ background: 'rgba(168,85,247,0.08)', borderColor: 'rgba(168,85,247,0.3)', color: '#d8b4fe' }}
+                                        >
+                                            {correlationLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Dumbbell className="w-4 h-4" />}
+                                            {correlationLoading ? 'Cruzando com seus treinos…' : 'Correlação com treino'}
+                                        </button>
+                                        {correlationError ? <p className="mt-2 text-sm text-red-400">{correlationError}</p> : null}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ) : null}
 
                     {stage === 'error' && (
                         <div className="py-10 flex flex-col items-center text-center gap-4">

--- a/src/components/body-photo/BodyPhotoCaptureModal.tsx
+++ b/src/components/body-photo/BodyPhotoCaptureModal.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import React, { useCallback, useRef, useState } from 'react'
+import NextImage from 'next/image'
+import { Camera, X, Check, Loader2, Sparkles, RotateCcw } from 'lucide-react'
+import { createBodyPhotoAssessment } from '@/actions/bodyPhotoAssessment-actions'
+import { analyzeBodyPhoto } from '@/lib/api/bodyPhoto'
+import { compressBodyPhoto, uploadBodyPhoto, type CompressedPhoto } from '@/utils/storage/bodyPhotoUpload'
+import { BODY_PHOTO_POSES, POSE_LABELS_PT, type BodyPhotoPose, type BodyPhotoLaudo } from '@/types/bodyPhotoAssessment'
+import { BodyPhotoLaudoView } from './BodyPhotoLaudoView'
+
+type Stage = 'capture' | 'processing' | 'result' | 'error'
+
+const POSE_HINT: Record<BodyPhotoPose, string> = {
+    front: 'Em pé, de frente, braços levemente afastados do corpo.',
+    side: 'De perfil, postura natural, olhando para frente.',
+    back: 'De costas, postura reta, braços relaxados.',
+}
+
+// Silhueta guia simples por pose (overlay translúcido pra enquadrar o corpo).
+const PoseSilhouette = ({ pose }: { pose: BodyPhotoPose }) => (
+    <svg viewBox="0 0 100 200" className="w-full h-full opacity-20" fill="none" stroke="currentColor" strokeWidth="2">
+        {/* cabeça */}
+        <circle cx="50" cy="22" r="13" />
+        {/* tronco + membros (variação leve por pose só pra orientar) */}
+        {pose === 'side' ? (
+            <path d="M50 35 C58 55 58 75 55 100 C54 130 56 160 58 190 M50 50 C44 70 44 90 46 110" strokeLinecap="round" />
+        ) : (
+            <path d="M50 35 L50 38 M30 60 C40 45 60 45 70 60 L66 110 L58 110 L55 190 M45 110 L42 190 M34 110 L40 60 M66 110 L60 60" strokeLinecap="round" strokeLinejoin="round" />
+        )}
+    </svg>
+)
+
+interface Props {
+    open: boolean
+    onClose: () => void
+    /** user_id do aluno (fluxo personal). Omitido = autoavaliação. */
+    studentUserId?: string | null
+    /** Chamado após gerar o laudo com sucesso (ex.: recarregar histórico). */
+    onSaved?: () => void
+}
+
+export const BodyPhotoCaptureModal: React.FC<Props> = ({ open, onClose, studentUserId, onSaved }) => {
+    const [stage, setStage] = useState<Stage>('capture')
+    const [photos, setPhotos] = useState<Partial<Record<BodyPhotoPose, CompressedPhoto>>>({})
+    const [busyPose, setBusyPose] = useState<BodyPhotoPose | null>(null)
+    const [progress, setProgress] = useState('')
+    const [laudo, setLaudo] = useState<BodyPhotoLaudo | null>(null)
+    const [errorMsg, setErrorMsg] = useState('')
+    const inputRefs = useRef<Record<BodyPhotoPose, HTMLInputElement | null>>({ front: null, side: null, back: null })
+
+    const reset = useCallback(() => {
+        setStage('capture'); setPhotos({}); setProgress(''); setLaudo(null); setErrorMsg(''); setBusyPose(null)
+    }, [])
+
+    const handleClose = useCallback(() => {
+        if (stage === 'processing') return // não fecha no meio da análise
+        reset(); onClose()
+    }, [stage, reset, onClose])
+
+    const handleFile = useCallback(async (pose: BodyPhotoPose, files: FileList | null) => {
+        if (!files?.length) return
+        setBusyPose(pose)
+        try {
+            const compressed = await compressBodyPhoto(files[0])
+            setPhotos((prev) => ({ ...prev, [pose]: compressed }))
+        } catch (e) {
+            setErrorMsg(e instanceof Error ? e.message : 'Falha ao processar a foto.')
+        } finally {
+            setBusyPose(null)
+        }
+    }, [])
+
+    const capturedCount = (Object.keys(photos) as BodyPhotoPose[]).filter((p) => photos[p]).length
+    const canAnalyze = !!photos.front && capturedCount >= 1
+
+    const handleAnalyze = useCallback(async () => {
+        if (!canAnalyze) return
+        setStage('processing'); setErrorMsg('')
+        try {
+            setProgress('Criando avaliação…')
+            const created = await createBodyPhotoAssessment({ studentUserId: studentUserId ?? null })
+            if (!created.ok) throw new Error(created.error || 'Falha ao criar avaliação.')
+            const id = created.data.id
+
+            for (const pose of BODY_PHOTO_POSES) {
+                const photo = photos[pose]
+                if (!photo) continue
+                setProgress(`Enviando foto: ${POSE_LABELS_PT[pose]}…`)
+                const up = await uploadBodyPhoto(id, pose, photo)
+                if (!up.ok) throw new Error(up.error || `Falha ao enviar foto ${POSE_LABELS_PT[pose]}.`)
+            }
+
+            setProgress('Analisando com IA… isso pode levar alguns segundos.')
+            const res = await analyzeBodyPhoto(id)
+            if (!res.ok || !res.analysis) throw new Error(res.message || res.error || 'Falha na análise.')
+
+            setLaudo(res.analysis)
+            setStage('result')
+            try { onSaved?.() } catch { /* noop */ }
+        } catch (e) {
+            setErrorMsg(e instanceof Error ? e.message : 'Erro inesperado.')
+            setStage('error')
+        }
+    }, [canAnalyze, photos, studentUserId, onSaved])
+
+    if (!open) return null
+
+    return (
+        <div className="fixed inset-0 z-[2200] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm p-0 sm:p-4">
+            <div className="w-full sm:max-w-2xl max-h-[92vh] flex flex-col rounded-t-3xl sm:rounded-3xl border border-neutral-800 bg-neutral-950 overflow-hidden">
+                {/* Header */}
+                <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-800 shrink-0">
+                    <div className="flex items-center gap-2.5">
+                        <div className="w-9 h-9 rounded-xl flex items-center justify-center" style={{ background: 'rgba(234,179,8,0.12)', border: '1px solid rgba(234,179,8,0.2)' }}>
+                            <Sparkles className="w-5 h-5 text-yellow-500" />
+                        </div>
+                        <div>
+                            <h2 className="text-base font-black text-white leading-tight">Avaliação por Foto</h2>
+                            <p className="text-[11px] text-neutral-500">Laudo de composição corporal por IA</p>
+                        </div>
+                    </div>
+                    <button onClick={handleClose} disabled={stage === 'processing'} aria-label="Fechar"
+                        className="w-9 h-9 rounded-xl border border-neutral-700 text-neutral-400 hover:text-white hover:border-yellow-500/40 transition disabled:opacity-40 flex items-center justify-center">
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                {/* Body */}
+                <div className="flex-1 overflow-y-auto p-5">
+                    {stage === 'capture' && (
+                        <div className="space-y-4">
+                            <p className="text-sm text-neutral-400">
+                                Tire ou escolha as 3 fotos. A de <span className="text-yellow-400 font-bold">frente</span> é obrigatória; perfil e costas deixam o laudo mais preciso. Use roupa justa, boa luz e corpo inteiro no quadro.
+                            </p>
+                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                                {BODY_PHOTO_POSES.map((pose) => {
+                                    const photo = photos[pose]
+                                    const isBusy = busyPose === pose
+                                    return (
+                                        <div key={pose} className="rounded-2xl border border-neutral-800 bg-neutral-900/50 overflow-hidden">
+                                            <div className="relative aspect-[3/4] bg-neutral-900 text-yellow-500/70 flex items-center justify-center">
+                                                {photo ? (
+                                                    <NextImage src={photo.previewDataUrl} alt={POSE_LABELS_PT[pose]} fill className="object-cover" unoptimized />
+                                                ) : (
+                                                    <div className="absolute inset-0 p-4"><PoseSilhouette pose={pose} /></div>
+                                                )}
+                                                {photo ? (
+                                                    <div className="absolute top-2 right-2 w-6 h-6 rounded-full bg-emerald-500 text-black flex items-center justify-center">
+                                                        <Check className="w-4 h-4" />
+                                                    </div>
+                                                ) : null}
+                                                {isBusy ? (
+                                                    <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                                                        <Loader2 className="w-6 h-6 text-yellow-500 animate-spin" />
+                                                    </div>
+                                                ) : null}
+                                            </div>
+                                            <div className="p-2.5">
+                                                <div className="flex items-center justify-between">
+                                                    <span className="text-sm font-bold text-white">{POSE_LABELS_PT[pose]}</span>
+                                                    {pose === 'front' ? <span className="text-[9px] uppercase font-black text-yellow-500">Obrigatória</span> : null}
+                                                </div>
+                                                <p className="text-[11px] text-neutral-500 leading-snug mt-0.5 min-h-[28px]">{POSE_HINT[pose]}</p>
+                                                <button
+                                                    onClick={() => inputRefs.current[pose]?.click()}
+                                                    className="mt-2 w-full inline-flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-xs font-bold transition active:scale-95 border"
+                                                    style={{ background: 'rgba(234,179,8,0.08)', borderColor: 'rgba(234,179,8,0.3)', color: '#fde047' }}
+                                                >
+                                                    <Camera className="w-3.5 h-3.5" />
+                                                    {photo ? 'Trocar' : 'Adicionar'}
+                                                </button>
+                                                <input
+                                                    ref={(el) => { inputRefs.current[pose] = el }}
+                                                    type="file" accept="image/*" capture="environment" className="hidden"
+                                                    aria-label={`Foto ${POSE_LABELS_PT[pose]}`}
+                                                    onChange={(e) => handleFile(pose, e.target.files)}
+                                                />
+                                            </div>
+                                        </div>
+                                    )
+                                })}
+                            </div>
+                            {errorMsg ? <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">{errorMsg}</p> : null}
+                            <p className="text-[11px] text-neutral-600">Suas fotos ficam privadas (bucket criptografado, só você e seu personal acessam) e podem ser apagadas a qualquer momento.</p>
+                        </div>
+                    )}
+
+                    {stage === 'processing' && (
+                        <div className="py-12 flex flex-col items-center justify-center text-center gap-4">
+                            <Loader2 className="w-10 h-10 text-yellow-500 animate-spin" />
+                            <div>
+                                <p className="text-white font-bold">{progress || 'Processando…'}</p>
+                                <p className="text-xs text-neutral-500 mt-1">Não feche esta janela.</p>
+                            </div>
+                        </div>
+                    )}
+
+                    {stage === 'result' && laudo ? <BodyPhotoLaudoView laudo={laudo} /> : null}
+
+                    {stage === 'error' && (
+                        <div className="py-10 flex flex-col items-center text-center gap-4">
+                            <div className="w-12 h-12 rounded-full bg-red-500/10 border border-red-500/30 flex items-center justify-center">
+                                <X className="w-6 h-6 text-red-400" />
+                            </div>
+                            <p className="text-sm text-neutral-300 max-w-sm">{errorMsg || 'Não foi possível concluir a análise.'}</p>
+                        </div>
+                    )}
+                </div>
+
+                {/* Footer */}
+                <div className="px-5 py-4 border-t border-neutral-800 shrink-0">
+                    {stage === 'capture' && (
+                        <button
+                            onClick={handleAnalyze}
+                            disabled={!canAnalyze}
+                            className="w-full min-h-[48px] rounded-xl text-black font-black shadow-lg shadow-yellow-500/20 hover:shadow-yellow-500/30 transition active:scale-95 inline-flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed btn-gold-animated"
+                        >
+                            <Sparkles className="w-5 h-5" />
+                            Analisar {capturedCount > 0 ? `(${capturedCount}/3)` : ''}
+                        </button>
+                    )}
+                    {stage === 'result' && (
+                        <div className="flex gap-2">
+                            <button onClick={reset} className="flex-1 min-h-[48px] rounded-xl border border-neutral-700 text-neutral-200 font-bold hover:border-yellow-500/40 transition active:scale-95 inline-flex items-center justify-center gap-2">
+                                <RotateCcw className="w-4 h-4" /> Nova
+                            </button>
+                            <button onClick={handleClose} className="flex-1 min-h-[48px] rounded-xl text-black font-black transition active:scale-95 btn-gold-animated">
+                                Concluir
+                            </button>
+                        </div>
+                    )}
+                    {stage === 'error' && (
+                        <button onClick={() => setStage('capture')} className="w-full min-h-[48px] rounded-xl border border-neutral-700 text-neutral-200 font-bold hover:border-yellow-500/40 transition active:scale-95">
+                            Tentar de novo
+                        </button>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/body-photo/BodyPhotoCorrelationView.tsx
+++ b/src/components/body-photo/BodyPhotoCorrelationView.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import React from 'react'
+import { Dumbbell, TrendingUp } from 'lucide-react'
+import {
+    type BodyPhotoCorrelation,
+    type TrainingWindowSummary,
+    CORRELATION_TREND_LABELS_PT,
+} from '@/types/bodyPhotoAssessment'
+
+const TREND_STYLE: Record<BodyPhotoCorrelation['links'][number]['trend'], { c: string; b: string; bg: string }> = {
+    supported: { c: '#86efac', b: 'rgba(34,197,94,0.3)', bg: 'rgba(34,197,94,0.08)' },
+    undertrained: { c: '#fdba74', b: 'rgba(249,115,22,0.3)', bg: 'rgba(249,115,22,0.08)' },
+    overtrained: { c: '#fca5a5', b: 'rgba(239,68,68,0.3)', bg: 'rgba(239,68,68,0.08)' },
+    neutral: { c: '#cbd5e1', b: 'rgba(148,163,184,0.3)', bg: 'rgba(148,163,184,0.08)' },
+}
+
+const Stat = ({ label, value }: { label: string; value: string }) => (
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/40 px-3 py-2 text-center">
+        <div className="text-lg font-black text-white leading-none">{value}</div>
+        <div className="text-[10px] uppercase tracking-widest font-bold text-neutral-500 mt-1">{label}</div>
+    </div>
+)
+
+export const BodyPhotoCorrelationView: React.FC<{
+    correlation: BodyPhotoCorrelation
+    window: TrainingWindowSummary
+}> = ({ correlation, window }) => {
+    const hasTraining = window.sessions > 0
+    return (
+        <div className="space-y-4">
+            {/* Header */}
+            <div className="flex items-center gap-2">
+                <Dumbbell className="w-4 h-4 text-yellow-500" />
+                <h3 className="text-sm font-black uppercase tracking-widest text-yellow-500/90">Correlação com o treino</h3>
+            </div>
+
+            {/* Stats da janela */}
+            <div className="grid grid-cols-3 gap-2">
+                <Stat label="Sessões" value={String(window.sessions)} />
+                <Stat label="Volume" value={`${(window.totalVolumeKg / 1000).toFixed(1)}t`} />
+                <Stat label="Séries" value={String(window.totalSets)} />
+            </div>
+
+            {!hasTraining ? (
+                <p className="text-sm text-orange-300/90 bg-orange-500/10 border border-orange-500/20 rounded-lg px-3 py-2">
+                    Nenhum treino registrado nesta janela — registre treinos no app pra desbloquear a correlação completa.
+                </p>
+            ) : null}
+
+            {/* Headline + narrativa */}
+            {correlation.headline ? (
+                <div className="rounded-2xl border p-4" style={{ background: 'linear-gradient(160deg, rgba(20,18,10,0.9), rgba(12,12,12,0.95))', borderColor: 'rgba(234,179,8,0.15)' }}>
+                    <div className="flex items-start gap-2">
+                        <TrendingUp className="w-4 h-4 text-yellow-400 mt-0.5 shrink-0" />
+                        <p className="text-sm font-bold text-white leading-snug">{correlation.headline}</p>
+                    </div>
+                    {correlation.narrative ? <p className="mt-2 text-sm text-neutral-300 leading-relaxed">{correlation.narrative}</p> : null}
+                </div>
+            ) : null}
+
+            {/* Top exercícios */}
+            {window.topExercises?.length ? (
+                <div className="space-y-1.5">
+                    <h4 className="text-[11px] uppercase tracking-widest font-black text-neutral-500">Mais treinados no período</h4>
+                    {window.topExercises.slice(0, 5).map((ex, i) => (
+                        <div key={i} className="flex items-center justify-between text-sm">
+                            <span className="text-neutral-300 truncate">{ex.name}</span>
+                            <span className="text-neutral-500 shrink-0 ml-2">{(ex.volumeKg / 1000).toFixed(1)}t · {ex.sets} séries</span>
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+
+            {/* Ligações grupo × treino */}
+            {correlation.links?.length ? (
+                <div className="space-y-2">
+                    <h4 className="text-[11px] uppercase tracking-widest font-black text-yellow-500/80">Grupo muscular × treino</h4>
+                    {correlation.links.map((l, i) => {
+                        const s = TREND_STYLE[l.trend]
+                        return (
+                            <div key={i} className="rounded-xl border border-neutral-800 bg-neutral-900/40 p-3">
+                                <div className="flex items-center justify-between gap-2">
+                                    <span className="text-sm font-bold text-white">{l.muscleGroup}</span>
+                                    <span className="text-[10px] uppercase tracking-wide font-black px-2 py-0.5 rounded-full border shrink-0" style={{ color: s.c, borderColor: s.b, background: s.bg }}>
+                                        {CORRELATION_TREND_LABELS_PT[l.trend]}
+                                    </span>
+                                </div>
+                                {l.observation ? <p className="mt-1 text-sm text-neutral-400 leading-snug">{l.observation}</p> : null}
+                            </div>
+                        )
+                    })}
+                </div>
+            ) : null}
+
+            {/* Funcionando / faltando */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {correlation.whatIsWorking?.length ? (
+                    <div className="space-y-1.5">
+                        <h4 className="text-[11px] uppercase tracking-widest font-black text-emerald-400/80">Funcionando</h4>
+                        <ul className="space-y-1.5">
+                            {correlation.whatIsWorking.map((it, i) => (
+                                <li key={i} className="flex items-start gap-2 text-sm text-neutral-300"><span className="mt-1 text-emerald-400">•</span><span className="leading-snug">{it}</span></li>
+                            ))}
+                        </ul>
+                    </div>
+                ) : null}
+                {correlation.whatIsMissing?.length ? (
+                    <div className="space-y-1.5">
+                        <h4 className="text-[11px] uppercase tracking-widest font-black text-orange-400/80">Faltando</h4>
+                        <ul className="space-y-1.5">
+                            {correlation.whatIsMissing.map((it, i) => (
+                                <li key={i} className="flex items-start gap-2 text-sm text-neutral-300"><span className="mt-1 text-orange-400">•</span><span className="leading-snug">{it}</span></li>
+                            ))}
+                        </ul>
+                    </div>
+                ) : null}
+            </div>
+
+            {/* Próximo foco */}
+            {correlation.nextFocus?.length ? (
+                <div className="space-y-2">
+                    <h4 className="text-[11px] uppercase tracking-widest font-black text-yellow-500/80">Próximo foco</h4>
+                    {correlation.nextFocus.map((f, i) => (
+                        <div key={i} className="rounded-xl border border-neutral-800 bg-neutral-900/40 p-3">
+                            <span className="text-sm font-bold text-white">{f.focus}</span>
+                            <p className="mt-1 text-sm text-neutral-300 leading-snug">{f.action}</p>
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/src/components/body-photo/BodyPhotoLaudoView.tsx
+++ b/src/components/body-photo/BodyPhotoLaudoView.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import React from 'react'
+import {
+    type BodyPhotoLaudo,
+    DEVELOPMENT_LABELS_PT,
+    PHASE_LABELS_PT,
+    type MuscleGroupAssessment,
+} from '@/types/bodyPhotoAssessment'
+
+// ─── Score ring ──────────────────────────────────────────────────────────────
+
+const scoreColor = (v: number): string => {
+    if (v >= 80) return '#22c55e'
+    if (v >= 60) return '#eab308'
+    if (v >= 40) return '#f97316'
+    return '#ef4444'
+}
+
+const ScoreRing = ({ label, value }: { label: string; value: number }) => {
+    const r = 26
+    const c = 2 * Math.PI * r
+    const pct = Math.max(0, Math.min(100, value))
+    const dash = (pct / 100) * c
+    const color = scoreColor(pct)
+    return (
+        <div className="flex flex-col items-center gap-1.5">
+            <div className="relative w-[68px] h-[68px]">
+                <svg width="68" height="68" className="-rotate-90">
+                    <circle cx="34" cy="34" r={r} fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="6" />
+                    <circle
+                        cx="34" cy="34" r={r} fill="none" stroke={color} strokeWidth="6" strokeLinecap="round"
+                        strokeDasharray={`${dash} ${c}`}
+                    />
+                </svg>
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-sm font-black text-white">{Math.round(pct)}</span>
+                </div>
+            </div>
+            <span className="text-[10px] uppercase tracking-widest font-bold text-neutral-400">{label}</span>
+        </div>
+    )
+}
+
+// ─── Muscle group chip ─────────────────────────────────────────────────────────
+
+const DEV_STYLE: Record<MuscleGroupAssessment['development'], { bg: string; border: string; text: string }> = {
+    weak: { bg: 'rgba(239,68,68,0.08)', border: 'rgba(239,68,68,0.3)', text: '#fca5a5' },
+    moderate: { bg: 'rgba(249,115,22,0.08)', border: 'rgba(249,115,22,0.3)', text: '#fdba74' },
+    good: { bg: 'rgba(234,179,8,0.08)', border: 'rgba(234,179,8,0.3)', text: '#fde047' },
+    excellent: { bg: 'rgba(34,197,94,0.08)', border: 'rgba(34,197,94,0.3)', text: '#86efac' },
+}
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div className="space-y-2">
+        <h4 className="text-[11px] uppercase tracking-widest font-black text-yellow-500/80">{title}</h4>
+        {children}
+    </div>
+)
+
+const BulletList = ({ items, tone }: { items: string[]; tone: 'good' | 'bad' }) => {
+    if (!items?.length) return null
+    const dot = tone === 'good' ? 'text-emerald-400' : 'text-orange-400'
+    return (
+        <ul className="space-y-1.5">
+            {items.map((it, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-neutral-300">
+                    <span className={`mt-1 ${dot}`}>•</span>
+                    <span className="leading-snug">{it}</span>
+                </li>
+            ))}
+        </ul>
+    )
+}
+
+export const BodyPhotoLaudoView: React.FC<{ laudo: BodyPhotoLaudo }> = ({ laudo }) => {
+    const priorityRank = { high: 0, medium: 1, low: 2 } as const
+    const recs = [...(laudo.recommendations || [])].sort((a, b) => priorityRank[a.priority] - priorityRank[b.priority])
+
+    return (
+        <div className="space-y-5">
+            {/* Headline: faixa de gordura + fase */}
+            <div
+                className="rounded-2xl border p-5"
+                style={{
+                    background: 'linear-gradient(160deg, rgba(20,18,10,0.9), rgba(12,12,12,0.95))',
+                    borderColor: 'rgba(234,179,8,0.15)',
+                }}
+            >
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div>
+                        <span className="text-[10px] uppercase tracking-widest font-bold text-neutral-400">Gordura corporal (estimativa)</span>
+                        <div className="text-3xl font-black text-white">
+                            {laudo.bodyFatRange.low}–{laudo.bodyFatRange.high}<span className="text-lg text-neutral-400">%</span>
+                        </div>
+                    </div>
+                    <div className="text-right">
+                        <span className="text-[10px] uppercase tracking-widest font-bold text-neutral-400">Fase aparente</span>
+                        <div className="text-sm font-bold text-yellow-400">{PHASE_LABELS_PT[laudo.apparentPhase]}</div>
+                        {laudo.somatotype ? <div className="text-xs text-neutral-500">{laudo.somatotype}</div> : null}
+                    </div>
+                </div>
+                {laudo.confidence === 'low' ? (
+                    <p className="mt-3 text-xs text-orange-300/90 bg-orange-500/10 border border-orange-500/20 rounded-lg px-3 py-2">
+                        Confiança baixa — fotos com corpo inteiro, boa luz e fundo neutro melhoram a análise.
+                    </p>
+                ) : null}
+            </div>
+
+            {/* Scores */}
+            <div className="grid grid-cols-4 gap-2 rounded-2xl border border-neutral-800 bg-neutral-900/40 p-4">
+                <ScoreRing label="Composição" value={laudo.scores.composition} />
+                <ScoreRing label="Simetria" value={laudo.scores.symmetry} />
+                <ScoreRing label="Postura" value={laudo.scores.posture} />
+                <ScoreRing label="Proporção" value={laudo.scores.proportion} />
+            </div>
+
+            {/* Resumo */}
+            {laudo.summary ? (
+                <p className="text-sm text-neutral-200 leading-relaxed bg-neutral-900/40 border border-neutral-800 rounded-xl p-4">
+                    {laudo.summary}
+                </p>
+            ) : null}
+
+            {/* Grupos musculares */}
+            {laudo.muscleGroups?.length ? (
+                <Section title="Por grupo muscular">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        {laudo.muscleGroups.map((g, i) => {
+                            const s = DEV_STYLE[g.development]
+                            return (
+                                <div key={i} className="rounded-xl border p-3" style={{ background: s.bg, borderColor: s.border }}>
+                                    <div className="flex items-center justify-between">
+                                        <span className="text-sm font-bold text-white">{g.group}</span>
+                                        <span className="text-[10px] uppercase tracking-wide font-black" style={{ color: s.text }}>
+                                            {DEVELOPMENT_LABELS_PT[g.development]}
+                                        </span>
+                                    </div>
+                                    {g.note ? <p className="mt-1 text-xs text-neutral-400 leading-snug">{g.note}</p> : null}
+                                </div>
+                            )
+                        })}
+                    </div>
+                </Section>
+            ) : null}
+
+            {/* Postura + Simetria */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {laudo.posture?.summary || laudo.posture?.findings?.length ? (
+                    <Section title="Postura">
+                        {laudo.posture.summary ? <p className="text-sm text-neutral-300 leading-snug">{laudo.posture.summary}</p> : null}
+                        <BulletList items={laudo.posture.findings} tone="bad" />
+                    </Section>
+                ) : null}
+                {laudo.symmetry?.summary || laudo.symmetry?.imbalances?.length ? (
+                    <Section title="Simetria L/R">
+                        {laudo.symmetry.summary ? <p className="text-sm text-neutral-300 leading-snug">{laudo.symmetry.summary}</p> : null}
+                        <BulletList items={laudo.symmetry.imbalances} tone="bad" />
+                    </Section>
+                ) : null}
+            </div>
+
+            {/* Proporções */}
+            {laudo.proportions?.summary ? (
+                <Section title="Proporções">
+                    <p className="text-sm text-neutral-300 leading-snug">{laudo.proportions.summary}</p>
+                    {laudo.proportions.shoulderToWaist ? (
+                        <p className="text-xs text-neutral-500">Ombro/cintura: {laudo.proportions.shoulderToWaist}</p>
+                    ) : null}
+                </Section>
+            ) : null}
+
+            {/* Pontos fortes / a melhorar */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {laudo.strengths?.length ? (
+                    <Section title="Pontos fortes"><BulletList items={laudo.strengths} tone="good" /></Section>
+                ) : null}
+                {laudo.improvements?.length ? (
+                    <Section title="A melhorar"><BulletList items={laudo.improvements} tone="bad" /></Section>
+                ) : null}
+            </div>
+
+            {/* Recomendações */}
+            {recs.length ? (
+                <Section title="Recomendações">
+                    <div className="space-y-2">
+                        {recs.map((r, i) => {
+                            const pill =
+                                r.priority === 'high' ? { t: 'Alta', c: '#fca5a5', b: 'rgba(239,68,68,0.3)', bg: 'rgba(239,68,68,0.08)' }
+                                    : r.priority === 'medium' ? { t: 'Média', c: '#fde047', b: 'rgba(234,179,8,0.3)', bg: 'rgba(234,179,8,0.08)' }
+                                        : { t: 'Baixa', c: '#93c5fd', b: 'rgba(59,130,246,0.3)', bg: 'rgba(59,130,246,0.08)' }
+                            return (
+                                <div key={i} className="rounded-xl border border-neutral-800 bg-neutral-900/40 p-3">
+                                    <div className="flex items-center justify-between gap-2">
+                                        <span className="text-sm font-bold text-white">{r.focus}</span>
+                                        <span
+                                            className="text-[10px] uppercase tracking-wide font-black px-2 py-0.5 rounded-full border shrink-0"
+                                            style={{ color: pill.c, borderColor: pill.b, background: pill.bg }}
+                                        >
+                                            {pill.t}
+                                        </span>
+                                    </div>
+                                    <p className="mt-1 text-sm text-neutral-300 leading-snug">{r.action}</p>
+                                </div>
+                            )
+                        })}
+                    </div>
+                </Section>
+            ) : null}
+
+            <p className="text-[11px] text-neutral-600 leading-snug pt-1">
+                Estimativa visual gerada por IA — não substitui avaliação presencial, bioimpedância ou dobras cutâneas.
+            </p>
+        </div>
+    )
+}

--- a/src/lib/api/bodyPhoto.ts
+++ b/src/lib/api/bodyPhoto.ts
@@ -3,7 +3,7 @@
  * CRUD de escrita fica em src/actions/bodyPhotoAssessment-actions.ts;
  * aqui ficam as chamadas às API routes (leitura com signed URLs + análise IA).
  */
-import type { BodyPhotoAssessment, BodyPhotoAssessmentPhoto, BodyPhotoLaudo } from '@/types/bodyPhotoAssessment'
+import type { BodyPhotoAssessment, BodyPhotoAssessmentPhoto, BodyPhotoLaudo, BodyPhotoCorrelation, TrainingWindowSummary } from '@/types/bodyPhotoAssessment'
 
 export interface BodyPhotoListItem extends BodyPhotoAssessment {
     thumbnailUrl: string | null
@@ -48,6 +48,23 @@ export async function analyzeBodyPhoto(
         const json = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
         if (!res.ok || !json.ok) return { ok: false, error: json.error || 'Falha na análise.', message: json.message }
         return { ok: true, analysis: json.analysis as BodyPhotoLaudo }
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
+    }
+}
+
+export async function fetchBodyPhotoCorrelation(
+    assessmentId: string,
+): Promise<{ ok: boolean; correlation?: BodyPhotoCorrelation; window?: TrainingWindowSummary; error?: string; message?: string }> {
+    try {
+        const res = await fetch('/api/ai/body-composition-correlation', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ assessmentId }),
+        })
+        const json = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
+        if (!res.ok || !json.ok) return { ok: false, error: json.error || 'Falha na correlação.', message: json.message }
+        return { ok: true, correlation: json.correlation as BodyPhotoCorrelation, window: json.window as TrainingWindowSummary }
     } catch (e) {
         return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
     }

--- a/src/lib/api/bodyPhoto.ts
+++ b/src/lib/api/bodyPhoto.ts
@@ -1,0 +1,54 @@
+/**
+ * Client wrappers para a Avaliação Física por Foto.
+ * CRUD de escrita fica em src/actions/bodyPhotoAssessment-actions.ts;
+ * aqui ficam as chamadas às API routes (leitura com signed URLs + análise IA).
+ */
+import type { BodyPhotoAssessment, BodyPhotoAssessmentPhoto, BodyPhotoLaudo } from '@/types/bodyPhotoAssessment'
+
+export interface BodyPhotoListItem extends BodyPhotoAssessment {
+    thumbnailUrl: string | null
+}
+
+export interface BodyPhotoDetail {
+    assessment: BodyPhotoAssessment
+    photos: Array<BodyPhotoAssessmentPhoto & { signedUrl: string | null }>
+}
+
+export async function fetchBodyPhotoList(): Promise<{ ok: boolean; assessments?: BodyPhotoListItem[]; error?: string }> {
+    try {
+        const res = await fetch('/api/body-photo/assessments', { method: 'GET' })
+        const json = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
+        if (!res.ok || !json.ok) return { ok: false, error: json.error || 'Falha ao listar.' }
+        return { ok: true, assessments: json.assessments as BodyPhotoListItem[] }
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
+    }
+}
+
+export async function fetchBodyPhotoDetail(id: string): Promise<{ ok: boolean; detail?: BodyPhotoDetail; error?: string }> {
+    try {
+        const res = await fetch(`/api/body-photo/assessments?id=${encodeURIComponent(id)}`, { method: 'GET' })
+        const json = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
+        if (!res.ok || !json.ok) return { ok: false, error: json.error || 'Falha ao carregar.' }
+        return { ok: true, detail: { assessment: json.assessment, photos: json.photos } }
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
+    }
+}
+
+export async function analyzeBodyPhoto(
+    assessmentId: string,
+): Promise<{ ok: boolean; analysis?: BodyPhotoLaudo; error?: string; message?: string }> {
+    try {
+        const res = await fetch('/api/ai/body-composition-photo', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ assessmentId }),
+        })
+        const json = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
+        if (!res.ok || !json.ok) return { ok: false, error: json.error || 'Falha na análise.', message: json.message }
+        return { ok: true, analysis: json.analysis as BodyPhotoLaudo }
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
+    }
+}

--- a/src/types/bodyPhotoAssessment.ts
+++ b/src/types/bodyPhotoAssessment.ts
@@ -1,0 +1,156 @@
+// Tipos da Avaliação Física por Foto (laudo IA via Gemini Vision).
+//
+// O laudo é o coração da feature: vai além de "% de gordura" e entrega
+// análise por grupo muscular, postura, simetria L/R e proporções —
+// depois correlacionada com o histórico de treino do mesmo user_id.
+
+import { z } from 'zod'
+
+// ─── Enums de domínio ────────────────────────────────────────────────────────
+
+export const BODY_PHOTO_POSES = ['front', 'side', 'back'] as const
+export type BodyPhotoPose = (typeof BODY_PHOTO_POSES)[number]
+
+export const BODY_PHOTO_STATUSES = ['pending', 'uploading', 'analyzing', 'done', 'failed'] as const
+export type BodyPhotoAssessmentStatus = (typeof BODY_PHOTO_STATUSES)[number]
+
+export const POSE_LABELS_PT: Record<BodyPhotoPose, string> = {
+    front: 'Frente',
+    side: 'Perfil',
+    back: 'Costas',
+}
+
+// ─── Zod schema do laudo IA ──────────────────────────────────────────────────
+// Validado no servidor antes de gravar em body_photo_assessments.analysis.
+// Tudo com defaults/nullable pra nunca quebrar quando a IA omite um campo.
+
+export const MuscleGroupAssessmentSchema = z.object({
+    /** Grupo muscular avaliado (ex.: "Peitoral", "Ombros", "Costas", "Quadríceps"). */
+    group: z.string().min(1).max(60),
+    /** Nível de desenvolvimento aparente. */
+    development: z.enum(['weak', 'moderate', 'good', 'excellent']),
+    /** Observação curta sobre o grupo. */
+    note: z.string().max(400).default(''),
+})
+export type MuscleGroupAssessment = z.infer<typeof MuscleGroupAssessmentSchema>
+
+export const BodyPhotoRecommendationSchema = z.object({
+    /** Foco da recomendação (grupo/área). */
+    focus: z.string().min(1).max(80),
+    /** Ação concreta sugerida. */
+    action: z.string().min(1).max(400),
+    priority: z.enum(['high', 'medium', 'low']).default('medium'),
+})
+export type BodyPhotoRecommendation = z.infer<typeof BodyPhotoRecommendationSchema>
+
+export const BodyPhotoLaudoSchema = z.object({
+    /** Faixa de % de gordura (nunca número falso de precisão). */
+    bodyFatRange: z.object({
+        low: z.number().min(0).max(100),
+        high: z.number().min(0).max(100),
+    }),
+    /** Somatotipo aparente (ecto/meso/endo ou misto). Texto livre, nullable. */
+    somatotype: z.string().max(60).nullable().default(null),
+    /** Fase aparente do treino. */
+    apparentPhase: z.enum(['bulking', 'cutting', 'recomp', 'maintenance', 'unknown']).default('unknown'),
+
+    /** Scores 0–100 por categoria. */
+    scores: z.object({
+        composition: z.number().min(0).max(100),
+        symmetry: z.number().min(0).max(100),
+        posture: z.number().min(0).max(100),
+        proportion: z.number().min(0).max(100),
+    }),
+
+    /** Avaliação por grupo muscular. */
+    muscleGroups: z.array(MuscleGroupAssessmentSchema).max(20).default([]),
+
+    /** Análise postural. */
+    posture: z.object({
+        summary: z.string().max(600).default(''),
+        findings: z.array(z.string().max(200)).max(12).default([]),
+    }).default({ summary: '', findings: [] }),
+
+    /** Simetria lado esquerdo vs direito. */
+    symmetry: z.object({
+        summary: z.string().max(600).default(''),
+        imbalances: z.array(z.string().max(200)).max(12).default([]),
+    }).default({ summary: '', imbalances: [] }),
+
+    /** Proporções corporais (relação ombro/cintura, V-taper, etc.). */
+    proportions: z.object({
+        summary: z.string().max(600).default(''),
+        shoulderToWaist: z.string().max(120).nullable().default(null),
+    }).default({ summary: '', shoulderToWaist: null }),
+
+    strengths: z.array(z.string().max(200)).max(10).default([]),
+    improvements: z.array(z.string().max(200)).max(10).default([]),
+    recommendations: z.array(BodyPhotoRecommendationSchema).max(10).default([]),
+
+    /** Resumo executivo (2–4 frases). */
+    summary: z.string().max(1200).default(''),
+    /** Confiança da análise — UI avisa o usuário se baixa. */
+    confidence: z.enum(['high', 'medium', 'low']).default('medium'),
+})
+export type BodyPhotoLaudo = z.infer<typeof BodyPhotoLaudoSchema>
+
+// ─── Entidades (linhas do banco) ─────────────────────────────────────────────
+
+export interface BodyPhotoAssessment {
+    id: string
+    user_id: string
+    trainer_id: string | null
+    created_by: string
+    assessment_date: string
+    status: BodyPhotoAssessmentStatus
+    composition_score: number | null
+    symmetry_score: number | null
+    posture_score: number | null
+    proportion_score: number | null
+    body_fat_estimate_low: number | null
+    body_fat_estimate_high: number | null
+    analysis: BodyPhotoLaudo | null
+    ai_model: string | null
+    ai_analyzed_at: string | null
+    notes: string | null
+    created_at: string
+    updated_at: string
+}
+
+export interface BodyPhotoAssessmentPhoto {
+    id: string
+    assessment_id: string
+    user_id: string
+    pose: BodyPhotoPose
+    storage_path: string
+    width: number | null
+    height: number | null
+    file_size: number | null
+    mime_type: string | null
+    created_at: string
+}
+
+/** Avaliação + suas fotos (com signed URLs resolvidas) para a UI. */
+export interface BodyPhotoAssessmentWithPhotos extends BodyPhotoAssessment {
+    photos: Array<BodyPhotoAssessmentPhoto & { signedUrl?: string | null }>
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+export const isBodyPhotoPose = (v: unknown): v is BodyPhotoPose =>
+    typeof v === 'string' && (BODY_PHOTO_POSES as readonly string[]).includes(v)
+
+export const DEVELOPMENT_LABELS_PT: Record<MuscleGroupAssessment['development'], string> = {
+    weak: 'Fraco',
+    moderate: 'Moderado',
+    good: 'Bom',
+    excellent: 'Excelente',
+}
+
+export const PHASE_LABELS_PT: Record<BodyPhotoLaudo['apparentPhase'], string> = {
+    bulking: 'Bulking (ganho)',
+    cutting: 'Cutting (definição)',
+    recomp: 'Recomposição',
+    maintenance: 'Manutenção',
+    unknown: 'Indefinida',
+}

--- a/src/types/bodyPhotoAssessment.ts
+++ b/src/types/bodyPhotoAssessment.ts
@@ -94,6 +94,52 @@ export const BodyPhotoLaudoSchema = z.object({
 })
 export type BodyPhotoLaudo = z.infer<typeof BodyPhotoLaudoSchema>
 
+// ─── Correlação treino × corpo (Sprint 3) ───────────────────────────────────
+// O diferencial: cruza o laudo da foto com o volume REAL treinado na janela
+// entre a avaliação anterior e a atual (ou últimos 90 dias).
+
+export const BodyPhotoCorrelationSchema = z.object({
+    /** Frase-resumo de impacto (ex.: "Seu peitoral evoluiu — alto volume em supino no período"). */
+    headline: z.string().max(300).default(''),
+    /** Narrativa correlacionando treino executado e físico observado. */
+    narrative: z.string().max(2000).default(''),
+    whatIsWorking: z.array(z.string().max(240)).max(8).default([]),
+    whatIsMissing: z.array(z.string().max(240)).max(8).default([]),
+    /** Ligações grupo muscular ↔ treino no período. */
+    links: z.array(z.object({
+        muscleGroup: z.string().max(60),
+        observation: z.string().max(300),
+        trend: z.enum(['supported', 'undertrained', 'overtrained', 'neutral']),
+    })).max(15).default([]),
+    nextFocus: z.array(z.object({
+        focus: z.string().max(80),
+        action: z.string().max(300),
+    })).max(6).default([]),
+    confidence: z.enum(['high', 'medium', 'low']).default('medium'),
+})
+export type BodyPhotoCorrelation = z.infer<typeof BodyPhotoCorrelationSchema>
+
+export const CORRELATION_TREND_LABELS_PT: Record<
+    BodyPhotoCorrelation['links'][number]['trend'],
+    string
+> = {
+    supported: 'Sustentado pelo treino',
+    undertrained: 'Pouco treinado',
+    overtrained: 'Possível excesso',
+    neutral: 'Neutro',
+}
+
+/** Estatísticas da janela de treino retornadas junto da correlação. */
+export interface TrainingWindowSummary {
+    fromIso: string
+    toIso: string
+    hasPreviousAssessment: boolean
+    sessions: number
+    totalVolumeKg: number
+    totalSets: number
+    topExercises: Array<{ name: string; volumeKg: number; sets: number }>
+}
+
 // ─── Entidades (linhas do banco) ─────────────────────────────────────────────
 
 export interface BodyPhotoAssessment {

--- a/src/utils/bodyPhoto/trainingWindow.ts
+++ b/src/utils/bodyPhoto/trainingWindow.ts
@@ -1,0 +1,127 @@
+/**
+ * trainingWindow — agrega o treino REAL executado numa janela de datas, pra
+ * correlacionar com a avaliação por foto.
+ *
+ * Fonte: linhas da tabela `workouts` com is_template=false (sessões concluídas).
+ * O campo `notes` é um JSON-snapshot da sessão: { logs, exercises, totalTime... }.
+ *   - logs: Record<"exIdx-setIdx", { weight, reps, done, set_type, is_warmup }>
+ *   - exercises: Array<{ name, ... }>
+ *
+ * Só séries WORKING contam (warmup/feeler ignoradas), igual ao resto do app.
+ */
+import { isRecord } from '@/utils/report/formatters'
+
+export interface ExerciseVolume {
+    name: string
+    volumeKg: number
+    sets: number
+}
+
+export interface TrainingWindowStats {
+    sessions: number
+    totalVolumeKg: number
+    totalSets: number
+    /** Top exercícios por volume (desc). */
+    topExercises: ExerciseVolume[]
+}
+
+interface SessionRow {
+    notes?: unknown
+}
+
+const parseNotes = (raw: unknown): Record<string, unknown> | null => {
+    if (isRecord(raw)) return raw
+    if (typeof raw === 'string' && raw.trim()) {
+        try {
+            const v = JSON.parse(raw)
+            return isRecord(v) ? v : null
+        } catch {
+            return null
+        }
+    }
+    return null
+}
+
+/** Reps podem vir como "8/10" (feito/planejado) ou "8" ou "8,5". */
+const parseReps = (raw: unknown): number => {
+    const s = String(raw ?? '').replace(',', '.').trim()
+    if (!s) return 0
+    const first = s.includes('/') ? s.split('/')[0].trim() : s
+    const n = Number(first)
+    return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+const parseWeight = (raw: unknown): number => {
+    const n = Number(String(raw ?? '').replace(',', '.').trim())
+    return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+const isWorkingLog = (log: Record<string, unknown>): boolean => {
+    const t = (log.set_type ?? log.setType) as string | null | undefined
+    if (t === 'warmup' || t === 'feeler') return false
+    if (t === 'working') return true
+    return !(log.is_warmup ?? log.isWarmup)
+}
+
+/** Índice do exercício a partir da chave "exIdx-setIdx". */
+const exIdxFromKey = (key: string): number => {
+    const head = String(key).split('-')[0]
+    const n = Number.parseInt(head, 10)
+    return Number.isFinite(n) ? n : -1
+}
+
+/**
+ * Agrega as sessões de uma janela em estatísticas de treino por exercício.
+ * `rows` já deve vir filtrado por user + datas (is_template=false).
+ */
+export function aggregateTrainingWindow(rows: SessionRow[], topN = 8): TrainingWindowStats {
+    let totalVolumeKg = 0
+    let totalSets = 0
+    let sessions = 0
+    const byExercise = new Map<string, ExerciseVolume>()
+
+    for (const row of rows) {
+        const notes = parseNotes(row?.notes)
+        if (!notes) continue
+        const logs = isRecord(notes.logs) ? (notes.logs as Record<string, unknown>) : null
+        if (!logs) continue
+        const exercises = Array.isArray(notes.exercises) ? (notes.exercises as unknown[]) : []
+        const nameByIdx = (idx: number): string => {
+            const ex = exercises[idx]
+            const name = isRecord(ex) ? String(ex.name ?? '').trim() : ''
+            return name || `Exercício ${idx + 1}`
+        }
+
+        let sessionHadVolume = false
+        for (const [key, value] of Object.entries(logs)) {
+            if (!isRecord(value)) continue
+            if (!isWorkingLog(value)) continue
+            const w = parseWeight(value.weight)
+            const r = parseReps(value.reps)
+            if (w <= 0 || r <= 0) continue
+            const vol = w * r
+            totalVolumeKg += vol
+            totalSets += 1
+            sessionHadVolume = true
+            const idx = exIdxFromKey(key)
+            const name = idx >= 0 ? nameByIdx(idx) : 'Exercício'
+            const prev = byExercise.get(name) || { name, volumeKg: 0, sets: 0 }
+            prev.volumeKg += vol
+            prev.sets += 1
+            byExercise.set(name, prev)
+        }
+        if (sessionHadVolume) sessions += 1
+    }
+
+    const topExercises = [...byExercise.values()]
+        .sort((a, b) => b.volumeKg - a.volumeKg)
+        .slice(0, topN)
+        .map((e) => ({ name: e.name, volumeKg: Math.round(e.volumeKg), sets: e.sets }))
+
+    return {
+        sessions,
+        totalVolumeKg: Math.round(totalVolumeKg),
+        totalSets,
+        topExercises,
+    }
+}

--- a/src/utils/storage/bodyPhotoUpload.ts
+++ b/src/utils/storage/bodyPhotoUpload.ts
@@ -1,0 +1,118 @@
+/**
+ * bodyPhotoUpload — captura/compressão + upload de uma foto da avaliação
+ * por foto pro bucket PRIVADO body-photos.
+ *
+ * Fluxo (client-side):
+ *   1. Comprime via Canvas (máx 1080px, JPEG 0.85 — resolução boa pra análise IA).
+ *   2. Pede signed upload URL a /api/body-photo/signed-upload (cria a linha da foto).
+ *   3. uploadToSignedUrl direto no Storage.
+ *
+ * Bucket é privado: nunca há URL pública; leitura é via signed URL do servidor.
+ */
+import { createClient } from '@/utils/supabase/client'
+import type { BodyPhotoPose } from '@/types/bodyPhotoAssessment'
+
+const MAX_DIMENSION = 1080
+const JPEG_QUALITY = 0.85
+
+export interface CompressedPhoto {
+    file: File
+    previewDataUrl: string
+    width: number
+    height: number
+}
+
+/** Comprime um arquivo de imagem para JPEG redimensionado. */
+export function compressBodyPhoto(file: File): Promise<CompressedPhoto> {
+    return new Promise((resolve, reject) => {
+        if (!file.type.startsWith('image/')) {
+            reject(new Error('Arquivo não é uma imagem.'))
+            return
+        }
+        const reader = new FileReader()
+        reader.onerror = () => reject(new Error('Falha ao ler a imagem.'))
+        reader.onload = (e) => {
+            const img = new Image()
+            img.onerror = () => reject(new Error('Falha ao decodificar a imagem.'))
+            img.onload = () => {
+                const canvas = document.createElement('canvas')
+                const ctx = canvas.getContext('2d')
+                if (!ctx) {
+                    reject(new Error('Canvas indisponível.'))
+                    return
+                }
+                let width = img.width
+                let height = img.height
+                if (width > height && width > MAX_DIMENSION) {
+                    height = Math.round((height * MAX_DIMENSION) / width)
+                    width = MAX_DIMENSION
+                } else if (height > MAX_DIMENSION) {
+                    width = Math.round((width * MAX_DIMENSION) / height)
+                    height = MAX_DIMENSION
+                }
+                canvas.width = width
+                canvas.height = height
+                ctx.drawImage(img, 0, 0, width, height)
+                canvas.toBlob(
+                    (blob) => {
+                        if (!blob) {
+                            reject(new Error('Falha ao comprimir.'))
+                            return
+                        }
+                        const compressed = new File([blob], 'photo.jpg', { type: 'image/jpeg', lastModified: Date.now() })
+                        resolve({
+                            file: compressed,
+                            previewDataUrl: canvas.toDataURL('image/jpeg', JPEG_QUALITY),
+                            width,
+                            height,
+                        })
+                    },
+                    'image/jpeg',
+                    JPEG_QUALITY,
+                )
+            }
+            img.src = e.target?.result as string
+        }
+        reader.readAsDataURL(file)
+    })
+}
+
+export interface UploadPoseResult {
+    ok: boolean
+    error?: string
+}
+
+/** Pede signed URL e faz upload de uma foto (pose) da avaliação. */
+export async function uploadBodyPhoto(
+    assessmentId: string,
+    pose: BodyPhotoPose,
+    photo: CompressedPhoto,
+): Promise<UploadPoseResult> {
+    try {
+        const res = await fetch('/api/body-photo/signed-upload', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                assessmentId,
+                pose,
+                width: photo.width,
+                height: photo.height,
+                fileSize: photo.file.size,
+                mimeType: 'image/jpeg',
+            }),
+        })
+        const signed = await res.json().catch(() => ({ ok: false, error: 'invalid_response' }))
+        if (!res.ok || !signed.ok) {
+            return { ok: false, error: signed.error || 'Falha ao obter URL de upload.' }
+        }
+
+        const supabase = createClient()
+        const { error: upErr } = await supabase.storage
+            .from('body-photos')
+            .uploadToSignedUrl(signed.path, signed.token, photo.file, { contentType: 'image/jpeg' })
+        if (upErr) return { ok: false, error: upErr.message || 'Falha no upload.' }
+        return { ok: true }
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'Erro de rede.' }
+    }
+}

--- a/supabase/migrations/20260528120000_body_photo_assessments.sql
+++ b/supabase/migrations/20260528120000_body_photo_assessments.sql
@@ -1,0 +1,170 @@
+-- Migration: Body Photo Assessment (avaliação física por foto com IA)
+--
+-- Feature nova: usuário (ou personal) tira 3 fotos padronizadas (frente, perfil,
+-- costas) e o Gemini Vision gera um laudo estruturado de composição corporal,
+-- correlacionado com o histórico de treino do mesmo user_id.
+--
+-- Tabelas dedicadas (NÃO mexe na tabela `assessments` de produção que tem dados
+-- reais e 7 policies). Espelha o modelo de acesso dual da `assessments`:
+--   - dono (self-service):  auth.uid() = user_id
+--   - personal (mediado):   auth.uid() = trainer_id
+--
+-- Fotos ficam em bucket PRIVADO (body-photos). Diferente do bucket público
+-- bioimpedance-files — foto de corpo é sensível, nunca exposta publicamente.
+-- Acesso às imagens só via signed URL mintada no servidor após checagem.
+
+BEGIN;
+
+-- ── Tabela principal: laudo da avaliação por foto ───────────────────────────
+CREATE TABLE IF NOT EXISTS public.body_photo_assessments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  trainer_id      uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  created_by      uuid NOT NULL,
+  assessment_date date NOT NULL DEFAULT current_date,
+
+  -- Ciclo de vida da análise IA
+  status          text NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'uploading', 'analyzing', 'done', 'failed')),
+
+  -- Scores 0–100 (preenchidos pela IA; nullable até a análise rodar)
+  composition_score numeric CHECK (composition_score BETWEEN 0 AND 100),
+  symmetry_score    numeric CHECK (symmetry_score    BETWEEN 0 AND 100),
+  posture_score     numeric CHECK (posture_score     BETWEEN 0 AND 100),
+  proportion_score  numeric CHECK (proportion_score  BETWEEN 0 AND 100),
+
+  -- % gordura como FAIXA (não número falso de precisão). Ex: 14–17%.
+  body_fat_estimate_low  numeric CHECK (body_fat_estimate_low  BETWEEN 0 AND 100),
+  body_fat_estimate_high numeric CHECK (body_fat_estimate_high BETWEEN 0 AND 100),
+
+  -- Laudo completo estruturado (JSON validado por Zod no app antes de gravar)
+  analysis        jsonb,
+  ai_model        text,
+  ai_analyzed_at  timestamptz,
+
+  notes           text,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.body_photo_assessments
+  IS 'Avaliação física por foto + laudo IA (Gemini Vision). user_id = mesmo auth id de workouts (correlação treino×corpo).';
+COMMENT ON COLUMN public.body_photo_assessments.trainer_id
+  IS 'Personal que criou a avaliação (fluxo mediado). NULL em autoavaliação.';
+COMMENT ON COLUMN public.body_photo_assessments.analysis
+  IS 'Laudo estruturado da IA: pontos fortes/fracos por grupo, postura, simetria, recomendações.';
+
+-- ── Tabela de fotos (1 por pose) ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.body_photo_assessment_photos (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  assessment_id uuid NOT NULL REFERENCES public.body_photo_assessments (id) ON DELETE CASCADE,
+  user_id       uuid NOT NULL,  -- denormalizado p/ RLS e prefixo do storage path
+  pose          text NOT NULL CHECK (pose IN ('front', 'side', 'back')),
+  storage_path  text NOT NULL,  -- {user_id}/{assessment_id}/{pose}.jpg no bucket body-photos
+  width         integer,
+  height        integer,
+  file_size     integer,
+  mime_type     text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (assessment_id, pose)
+);
+
+COMMENT ON TABLE public.body_photo_assessment_photos
+  IS 'Fotos da avaliação (frente/perfil/costas). storage_path aponta pro bucket PRIVADO body-photos.';
+
+-- ── Índices ─────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_body_photo_assessments_user
+  ON public.body_photo_assessments (user_id, assessment_date DESC);
+CREATE INDEX IF NOT EXISTS idx_body_photo_assessments_trainer
+  ON public.body_photo_assessments (trainer_id)
+  WHERE trainer_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_body_photo_assessment_photos_assessment
+  ON public.body_photo_assessment_photos (assessment_id);
+
+-- ── updated_at trigger (padrão do projeto: função por tabela) ────────────────
+CREATE OR REPLACE FUNCTION public.body_photo_assessments_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $function$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS body_photo_assessments_touch ON public.body_photo_assessments;
+CREATE TRIGGER body_photo_assessments_touch
+  BEFORE UPDATE ON public.body_photo_assessments
+  FOR EACH ROW EXECUTE FUNCTION public.body_photo_assessments_touch_updated_at();
+
+-- ── RLS: avaliações ─────────────────────────────────────────────────────────
+ALTER TABLE public.body_photo_assessments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS body_photo_assessments_owner ON public.body_photo_assessments;
+CREATE POLICY body_photo_assessments_owner
+  ON public.body_photo_assessments
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS body_photo_assessments_trainer ON public.body_photo_assessments;
+CREATE POLICY body_photo_assessments_trainer
+  ON public.body_photo_assessments
+  FOR ALL
+  USING (auth.uid() = trainer_id)
+  WITH CHECK (auth.uid() = trainer_id);
+
+-- ── RLS: fotos ──────────────────────────────────────────────────────────────
+ALTER TABLE public.body_photo_assessment_photos ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS body_photo_photos_owner ON public.body_photo_assessment_photos;
+CREATE POLICY body_photo_photos_owner
+  ON public.body_photo_assessment_photos
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS body_photo_photos_trainer ON public.body_photo_assessment_photos;
+CREATE POLICY body_photo_photos_trainer
+  ON public.body_photo_assessment_photos
+  FOR ALL
+  USING (EXISTS (
+    SELECT 1 FROM public.body_photo_assessments a
+     WHERE a.id = body_photo_assessment_photos.assessment_id
+       AND a.trainer_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.body_photo_assessments a
+     WHERE a.id = body_photo_assessment_photos.assessment_id
+       AND a.trainer_id = auth.uid()
+  ));
+
+-- ── Storage: bucket PRIVADO body-photos ─────────────────────────────────────
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('body-photos', 'body-photos', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Owner gerencia objetos sob o próprio prefixo {user_id}/...
+-- (Personal acessa via signed URL mintada no servidor — admin client.)
+DROP POLICY IF EXISTS body_photos_owner_select ON storage.objects;
+CREATE POLICY body_photos_owner_select
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'body-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+DROP POLICY IF EXISTS body_photos_owner_insert ON storage.objects;
+CREATE POLICY body_photos_owner_insert
+  ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'body-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+DROP POLICY IF EXISTS body_photos_owner_update ON storage.objects;
+CREATE POLICY body_photos_owner_update
+  ON storage.objects FOR UPDATE
+  USING (bucket_id = 'body-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+DROP POLICY IF EXISTS body_photos_owner_delete ON storage.objects;
+CREATE POLICY body_photos_owner_delete
+  ON storage.objects FOR DELETE
+  USING (bucket_id = 'body-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+COMMIT;


### PR DESCRIPTION
## Resumo

Sprint 1+2 da Avaliação Física por Foto. Usuário (ou personal) tira 3 fotos padronizadas (frente/perfil/costas) e o **Gemini Vision** gera um laudo estruturado de composição corporal — o diferencial: `user_id` da avaliação é o mesmo de `workouts`, abrindo caminho pra correlação treino×corpo (Sprint 3).

## Backend
- **Tabelas novas isoladas** (não tocam a `assessments` de produção): `body_photo_assessments` + `body_photo_assessment_photos`. RLS dual — dono (`user_id`) + personal (`trainer_id`), espelhando o modelo da `assessments`.
- **Bucket PRIVADO** `body-photos` + storage policies por prefixo `{user_id}`. Foto de corpo nunca pública — leitura só via signed URL mintada no servidor.
- `POST /api/body-photo/signed-upload` — minta upload token (admin + access check) e cria a linha da foto.
- `GET /api/body-photo/assessments` — lista/detalhe com signed URLs.
- `POST /api/ai/body-composition-photo` — baixa as fotos do bucket privado, manda multimodal pro Gemini Vision (Pro), valida o laudo com Zod e grava `analysis` + scores.

## Frontend
- Modal de captura com **guia de pose** (silhuetas), compressão Canvas, upload via signed URL e disparo da análise.
- `BodyPhotoLaudoView`: 4 scores em anéis, faixa de gordura, grupos musculares, postura, simetria L/R, recomendações priorizadas.
- Botão **"Por Foto"** na aba Avaliações Físicas.

## Migration
- `20260528120000_body_photo_assessments.sql` — **já aplicada em produção** (tabelas + RLS + bucket verificados). Aditiva e isolada; sem risco aos dados existentes.

## Não-merge (aguarda review/teste)
Tem migration + feature nova grande. Não auto-mergear: testar o fluxo captura→upload→IA no preview da Vercel antes.

## Test plan
- [ ] Abrir aba Avaliações Físicas → botão "Por Foto"
- [ ] Capturar 3 fotos (frente obrigatória) → "Analisar"
- [ ] Verificar laudo renderiza (scores, grupos, recomendações)
- [ ] Confirmar fotos no bucket privado (signed URL funciona, sem acesso público)
- [ ] Testar fluxo personal (trainer avaliando aluno) e autoavaliação
- [ ] RLS: usuário não acessa avaliação de outro

🤖 Generated with [Claude Code](https://claude.com/claude-code)